### PR TITLE
Butterworth fliter when constructing a mask

### DIFF
--- a/flint/coadd/linmos.py
+++ b/flint/coadd/linmos.py
@@ -270,7 +270,7 @@ def generate_linmos_parameter_set(
         f"linmos.useweightslog    = true\n"
         f"linmos.weighttype       = Combined\n"
         f"linmos.weightstate      = Inherent\n"
-        f"linmos.cutoff           = 0.01\n"
+        f"linmos.cutoff           = 0.001\n"
     )
 
     # This requires an appropriate holography fits cube to

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -75,7 +75,7 @@ def create_snr_mask_wbutter_from_fits(
     fits_bkg_path: Path,
     create_signal_fits: bool = False,
     min_snr: float = 5,
-    connectivity_shape: Tuple[int,int] = (4,4)   
+    connectivity_shape: Tuple[int, int] = (4, 4),
 ) -> FITSMaskNames:
     """Create a mask for an input FITS image based on a signal to noise given a corresponding pair of RMS and background FITS images.
 
@@ -84,7 +84,7 @@ def create_snr_mask_wbutter_from_fits(
 
     Before deriving a signal map the image is first smoothed using a butterworth filter, and a
     crude rescaling factor is applied based on the ratio of the maximum pixel values before and
-    after the smoothing is applied. 
+    after the smoothing is applied.
 
     This is done in a staged manner to minimise the number of (potentially large) images
     held in memory.
@@ -93,7 +93,7 @@ def create_snr_mask_wbutter_from_fits(
     features offered by some tooling (e.g. BANE --compress) can not be used.
 
     Once the signal map as been computed, all pixels below ``min_snr`` are flagged. The resulting
-    islands then have a binary erosion applied to contract the resultingn islands. 
+    islands then have a binary erosion applied to contract the resultingn islands.
 
     Args:
         fits_image_path (Path): Path to the FITS file containing an image
@@ -116,18 +116,15 @@ def create_snr_mask_wbutter_from_fits(
 
         image_max = np.nanmax(fits_image[0].data)
         image_butter = butterworth(
-            np.nan_to_num(np.squeeze(fits_image[0].data)),
-            0.045,
-            high_pass=False
+            np.nan_to_num(np.squeeze(fits_image[0].data)), 0.045, high_pass=False
         )
-        
+
         butter_max = np.nanmax(image_butter)
-        scale_ratio = image_max / butter_max 
+        scale_ratio = image_max / butter_max
         logger.info(f"Scaling smoothed image by {scale_ratio:.4f}")
-        image_butter *= (image_max / butter_max)
-        
+        image_butter *= image_max / butter_max
+
     with fits.open(fits_bkg_path) as fits_bkg:
-        
         logger.info("Subtracting background")
         signal_data = image_butter - np.squeeze(fits_bkg[0].data)
 
@@ -267,16 +264,16 @@ def get_parser() -> ArgumentParser:
         help="The minimum SNR required for a pixel to be marked as valid. ",
     )
     fits_parser.add_argument(
-        '--use-butterworth',
-        action='store_true',
-        help='Apply a butterworth filter to smooth the total intensity image before computing the signal map. '
+        "--use-butterworth",
+        action="store_true",
+        help="Apply a butterworth filter to smooth the total intensity image before computing the signal map. ",
     )
     fits_parser.add_argument(
-        '--connectivity-shape',
-        default=(4,4),
+        "--connectivity-shape",
+        default=(4, 4),
         nargs=2,
         type=int,
-        help='The connectivity matrix to use when applying a binary erosion. Only used when using the butterworth smoothing filter. '
+        help="The connectivity matrix to use when applying a binary erosion. Only used when using the butterworth smoothing filter. ",
     )
 
     extract_parser = subparser.add_parser(
@@ -312,7 +309,7 @@ def cli():
                 fits_bkg_path=args.bkg,
                 create_signal_fits=args.save_signal,
                 min_snr=args.min_snr,
-                connectivity_shape=tuple(args.connectivity_shape)
+                connectivity_shape=tuple(args.connectivity_shape),
             )
         else:
             create_snr_mask_from_fits(
@@ -322,7 +319,7 @@ def cli():
                 create_signal_fits=args.save_signal,
                 min_snr=args.min_snr,
             )
-        
+
     elif args.mode == "extractmask":
         extract_beam_mask_from_mosaic(
             fits_beam_image_path=args.beam_image,

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -156,7 +156,7 @@ def create_snr_mask_wbutter_from_fits(
     logger.info(f"Writing {mask_names.mask_fits}")
     fits.writeto(
         filename=mask_names.mask_fits,
-        data=mask_data,
+        data=mask_data.astype(np.int32),
         header=fits_header,
     )
 

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -266,6 +266,18 @@ def get_parser() -> ArgumentParser:
         default=4,
         help="The minimum SNR required for a pixel to be marked as valid. ",
     )
+    fits_parser.add_argument(
+        '--use-butterworth',
+        action='store_true',
+        help='Apply a butterworth filter to smooth the total intensity image before computing the signal map. '
+    )
+    fits_parser.add_argument(
+        '--connectivity-shape',
+        default=(4,4),
+        nargs=2,
+        type=int,
+        help='The connectivity matrix to use when applying a binary erosion. Only used when using the butterworth smoothing filter. '
+    )
 
     extract_parser = subparser.add_parser(
         "extractmask",
@@ -293,13 +305,24 @@ def cli():
     args = parser.parse_args()
 
     if args.mode == "snrmask":
-        create_snr_mask_from_fits(
-            fits_image_path=args.image,
-            fits_rms_path=args.rms,
-            fits_bkg_path=args.bkg,
-            create_signal_fits=args.save_signal,
-            min_snr=args.min_snr,
-        )
+        if args.user_butterworth:
+            create_snr_mask_wbutter_from_fits(
+                fits_image_path=args.image,
+                fits_rms_path=args.rms,
+                fits_bkg_path=args.bkg,
+                create_signal_fits=args.save_signal,
+                min_snr=args.min_snr,
+                connectivity_shape=tuple(args.connectivity_shape)
+            )
+        else:
+            create_snr_mask_from_fits(
+                fits_image_path=args.image,
+                fits_rms_path=args.rms,
+                fits_bkg_path=args.bkg,
+                create_signal_fits=args.save_signal,
+                min_snr=args.min_snr,
+            )
+        
     elif args.mode == "extractmask":
         extract_beam_mask_from_mosaic(
             fits_beam_image_path=args.beam_image,

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -151,7 +151,7 @@ def create_snr_mask_wbutter_from_fits(
     mask_data = (signal_data > min_snr).astype(np.int32)
 
     logger.info(f"Applying binary erosion with {connectivity_shape=}")
-    mask_data = binary_erosion(mask_data, connectivity_shape)
+    mask_data = binary_erosion(mask_data, np.ones(connectivity_shape))
 
     logger.info(f"Writing {mask_names.mask_fits}")
     fits.writeto(

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -75,7 +75,7 @@ def create_snr_mask_wbutter_from_fits(
     fits_bkg_path: Path,
     create_signal_fits: bool = False,
     min_snr: float = 5,
-    connectivity_shape: Tuple[int,int] = (8,8)   
+    connectivity_shape: Tuple[int,int] = (4,4)   
 ) -> FITSMaskNames:
     """Create a mask for an input FITS image based on a signal to noise given a corresponding pair of RMS and background FITS images.
 
@@ -101,7 +101,7 @@ def create_snr_mask_wbutter_from_fits(
         fits_bkg_path (Path): Path to the FITS file with an baclground image corresponding to ``fits_image_path``
         create_signal_fits (bool, optional): Create an output signal map. Defaults to False.
         min_snr (float, optional): Minimum signal-to-noise ratio for the masking to include a pixel. Defaults to 3.5.
-        connectivity_shape (Tuple[int, int], optional): The connectivity matrix used in the scikit-image binary erosion applied to the mask. Defaults to (8, 8).
+        connectivity_shape (Tuple[int, int], optional): The connectivity matrix used in the scikit-image binary erosion applied to the mask. Defaults to (4, 4).
 
     Returns:
         FITSMaskNames: Container describing the signal and mask FITS image paths. If ``create_signal_path`` is None, then the ``signal_fits`` attribute will be None.
@@ -150,7 +150,6 @@ def create_snr_mask_wbutter_from_fits(
     logger.info(f"Clipping using a {min_snr=}")
     mask_data = (signal_data > min_snr).astype(np.int32)
 
-    connectivity_shape = (8,8)
     logger.info(f"Applying binary erosion with {connectivity_shape=}")
     mask_data = binary_erosion(mask_data, connectivity_shape)
 

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -402,7 +402,7 @@ def task_create_linmos_mask_model(
 def task_create_linmos_mask_wbutter_model(
     linmos_parset: LinmosCMD,
     image_products: AegeanOutputs,
-    min_snr: Optional[float] = 3.5,
+    min_snr: Optional[float] = 5,
 ) -> FITSMaskNames:
     """Create a mask from a linmos image, with the intention of providing it as a clean mask
     to an appropriate imager. This is derived using a simple signal to noise cut.
@@ -414,7 +414,7 @@ def task_create_linmos_mask_wbutter_model(
     Args:
         linmos_parset (LinmosCMD): Linmos command and associated meta-data
         image_products (AegeanOutputs): Images of the RMS and BKG
-        min_snr (float, optional): The minimum S/N a pixel should be for it to be included in the clean mask.
+        min_snr (float, optional): The minimum S/N a pixel should be for it to be included in the clean mask. Defaults to 5.
 
     Raises:
         ValueError: Raised when ``image_products`` are not known

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -399,7 +399,7 @@ def task_create_linmos_mask_model(
     return linmos_mask_names
 
 @task
-def task_create_linmos_mask__wbutter_model(
+def task_create_linmos_mask_wbutter_model(
     linmos_parset: LinmosCMD,
     image_products: AegeanOutputs,
     min_snr: Optional[float] = 3.5,

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -20,7 +20,7 @@ from flint.convol import BeamShape, convolve_images, get_common_beam
 from flint.flagging import flag_ms_aoflagger
 from flint.imager.wsclean import WSCleanCMD, wsclean_imager
 from flint.logging import logger
-from flint.masking import create_snr_mask_from_fits, extract_beam_mask_from_mosaic
+from flint.masking import create_snr_mask_wbutter_from_fits, create_snr_mask_from_fits, extract_beam_mask_from_mosaic
 from flint.ms import MS, preprocess_askap_ms, split_by_field
 from flint.naming import FITSMaskNames, processed_ms_format
 from flint.selfcal.casa import gaincal_applycal_ms
@@ -391,7 +391,54 @@ def task_create_linmos_mask_model(
         fits_bkg_path=linmos_bkg,
         fits_rms_path=linmos_rms,
         create_signal_fits=True,
-        min_snr=3,
+        min_snr=min_snr,
+    )
+
+    logger.info(f"Created {linmos_mask_names.mask_fits}")
+
+    return linmos_mask_names
+
+@task
+def task_create_linmos_mask__wbutter_model(
+    linmos_parset: LinmosCMD,
+    image_products: AegeanOutputs,
+    min_snr: Optional[float] = 3.5,
+) -> FITSMaskNames:
+    """Create a mask from a linmos image, with the intention of providing it as a clean mask
+    to an appropriate imager. This is derived using a simple signal to noise cut.
+
+    This will use a butterworth filter to first smooth the image before island thresdholds
+    are created. To account for the smooth a binary erosion operation is applied to the
+    resulting mask. 
+
+    Args:
+        linmos_parset (LinmosCMD): Linmos command and associated meta-data
+        image_products (AegeanOutputs): Images of the RMS and BKG
+        min_snr (float, optional): The minimum S/N a pixel should be for it to be included in the clean mask.
+
+    Raises:
+        ValueError: Raised when ``image_products`` are not known
+
+    Returns:
+        FITSMaskNames: Clean mask where all pixels below a S/N are masked
+    """
+    if isinstance(image_products, AegeanOutputs):
+        linmos_image = linmos_parset.image_fits
+        linmos_rms = image_products.rms
+        linmos_bkg = image_products.bkg
+    else:
+        raise ValueError("Unsupported bkg/rms mode. ")
+
+    logger.info(f"Creating a clean mask for {linmos_image=}")
+    logger.info(f"Using {linmos_rms=}")
+    logger.info(f"Using {linmos_bkg=}")
+
+    linmos_mask_names = create_snr_mask_wbutter_from_fits(
+        fits_image_path=linmos_image,
+        fits_bkg_path=linmos_bkg,
+        fits_rms_path=linmos_rms,
+        create_signal_fits=True,
+        min_snr=min_snr,
     )
 
     logger.info(f"Created {linmos_mask_names.mask_fits}")

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -20,7 +20,11 @@ from flint.convol import BeamShape, convolve_images, get_common_beam
 from flint.flagging import flag_ms_aoflagger
 from flint.imager.wsclean import WSCleanCMD, wsclean_imager
 from flint.logging import logger
-from flint.masking import create_snr_mask_wbutter_from_fits, create_snr_mask_from_fits, extract_beam_mask_from_mosaic
+from flint.masking import (
+    create_snr_mask_from_fits,
+    create_snr_mask_wbutter_from_fits,
+    extract_beam_mask_from_mosaic,
+)
 from flint.ms import MS, preprocess_askap_ms, split_by_field
 from flint.naming import FITSMaskNames, processed_ms_format
 from flint.selfcal.casa import gaincal_applycal_ms
@@ -398,6 +402,7 @@ def task_create_linmos_mask_model(
 
     return linmos_mask_names
 
+
 @task
 def task_create_linmos_mask_wbutter_model(
     linmos_parset: LinmosCMD,
@@ -409,7 +414,7 @@ def task_create_linmos_mask_wbutter_model(
 
     This will use a butterworth filter to first smooth the image before island thresdholds
     are created. To account for the smooth a binary erosion operation is applied to the
-    resulting mask. 
+    resulting mask.
 
     Args:
         linmos_parset (LinmosCMD): Linmos command and associated meta-data

--- a/flint/prefect/flows/continuum_mask_pipeline.py
+++ b/flint/prefect/flows/continuum_mask_pipeline.py
@@ -45,7 +45,7 @@ from flint.prefect.common.utils import task_flatten
 
 
 def _create_linmos_mask(
-    parset: Any, aegean_outputs: Any, butterworth_filter: bool
+    linmos_parset: Any, aegean_outputs: Any, butterworth_filter: bool
 ) -> Any:
     """A common function that pulls together the two linmos masking operations.
     This is an internal function that is calling prefect tasks. It itself can not be
@@ -54,12 +54,12 @@ def _create_linmos_mask(
     # At the moment no others tasks or flows should use this, ya filthy pirate.
     if butterworth_filter:
         linmos_mask = task_create_linmos_mask_wbutter_model(
-            linmos_parset=parset,
+            linmos_parset=linmos_parset,
             image_products=aegean_outputs,
         )
     else:
         linmos_mask = task_create_linmos_mask_model(
-            linmos_parset=parset,
+            linmos_parset=linmos_parset,
             image_products=aegean_outputs,
         )
 

--- a/flint/prefect/flows/continuum_mask_pipeline.py
+++ b/flint/prefect/flows/continuum_mask_pipeline.py
@@ -257,15 +257,21 @@ def process_science_fields(
         )
 
         # Use the mask from the first round
-        # if round < rounds:
-        #     linmos_mask = task_create_linmos_mask_model.submit(
-        #         linmos_parset=parset,
-        #         image_products=aegean_outputs,
-        #     )
+        if round < rounds:
+            if butter_mask_smooth:
+                linmos_mask = task_create_linmos_mask_wbutter_model(
+                    linmos_parset=parset,
+                    image_products=aegean_outputs,
+                )
+            else:
+                linmos_mask = task_create_linmos_mask_model(
+                    linmos_parset=parset,
+                    image_products=aegean_outputs,
+                )
 
-        #     beam_masks = task_extract_beam_mask_image.map(
-        #         linmos_mask_names=unmapped(linmos_mask), wsclean_cmd=wsclean_cmds
-        #     )
+            beam_masks = task_extract_beam_mask_image.map(
+                linmos_mask_names=unmapped(linmos_mask), wsclean_cmd=wsclean_cmds
+            )
 
         if run_validation:
             task_create_validation_plot.submit(

--- a/flint/prefect/flows/continuum_mask_pipeline.py
+++ b/flint/prefect/flows/continuum_mask_pipeline.py
@@ -14,7 +14,7 @@ imaging round.
 """
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Optional, Union, Any
+from typing import Any, Optional, Union
 
 from prefect import flow, unmapped
 

--- a/flint/prefect/flows/continuum_mask_pipeline.py
+++ b/flint/prefect/flows/continuum_mask_pipeline.py
@@ -190,7 +190,7 @@ def process_science_fields(
 
     linmos_mask = _create_linmos_mask(
         linmos_parset=parset,
-        image_products=aegean_outputs,
+        aegean_outputs=aegean_outputs,
         butterworth_filter=butterworth_filter,
     )
 
@@ -277,7 +277,7 @@ def process_science_fields(
         if round < rounds:
             linmos_mask = _create_linmos_mask(
                 linmos_parset=parset,
-                image_products=aegean_outputs,
+                aegean_outputs=aegean_outputs,
                 butterworth_filter=butterworth_filter,
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ aegeantools = "2.3.0"
 pytest = "^7.4.0"
 radio-beam = "^0.3.4"
 reproject = "*"
+scikit-image = "*"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.3.0"


### PR DESCRIPTION
I noticed in some linmos'd fields that there was regions of diffuse, low surface brightness emission that was not above the adopted S/N when constructing a clean mask. Although it is clearly there, it was not included and therefore not clean in subsequent imaging rounds. 

This pull request attempts to introduce a smoothing function that will draw out such diffuse emission so that is may be incorporated into the clean mask, and actually cleaned. 

At the moment the spatial frequency cuts and binary erosion is fairly fixed and were selected by eye. There are likely going to be other more intelligent ways of constructing the mask. I have heard mention of some methods implemented in miriad (or miriad imaging scripts) developed at ASTRON/WSRT. Curious what they are. 