### PR TITLE
Flagging and bandpass smoother

### DIFF
--- a/flint/bptools/smoother.py
+++ b/flint/bptools/smoother.py
@@ -6,7 +6,7 @@ from flint.logging import logger
 
 
 def smooth_data(
-    data: np.ndarray, window_size: int, polynomial_order: int, median_filter: bool = True
+    data: np.ndarray, window_size: int, polynomial_order: int, apply_median_filter: bool = True
 ) -> np.ndarray:
     """Smooth a 1-dimensional dataset. Internally it uses a savgol filter as
     implemented in scipy.signal.savgol_filter. It is intended to be used to
@@ -25,7 +25,7 @@ def smooth_data(
         data (np.ndarray): The 1-dimensional data to be smoothed.
         window_size (int): The size of the window function of the savgol filter. Passed directly to savgol.
         polynomial_order (int): The order of the polynomial of the savgol filter. Passed directly to savgol.
-        median_filter (bool, optional): Apply a median filter to the data before applying the savgol filter using the same window size. Defaults to True. 
+        apply_median_filter (bool, optional): Apply a median filter to the data before applying the savgol filter using the same window size. Defaults to True. 
         
     Returns:
         np.ndarray: Smoothed dataset
@@ -35,7 +35,7 @@ def smooth_data(
     # where ever it might be. Trust nothing you sea dog.
     data = data.copy()
 
-    if median_filter:
+    if apply_median_filter:
         data = median_filter(input=data, size=window_size)
 
     # Before we smooth we need to fill in channels that are flagged with nans.
@@ -60,7 +60,7 @@ def smooth_data(
 
 
 def smooth_bandpass_complex_gains(
-    complex_gains: np.ndarray, window_size: int = 16, polynomial_order: int = 4, median_filter: bool = True
+    complex_gains: np.ndarray, window_size: int = 16, polynomial_order: int = 4, apply_median_filter: bool = True
 ) -> np.ndarray:
     """Smooth bandpass solutions by applying a savgol filter to the real and imaginary components
     of each of the antenna based polarisation solutions across channels.
@@ -80,7 +80,7 @@ def smooth_bandpass_complex_gains(
         complex_gains (np.ndarray): Data to be smoothed.
         window_size (int, optional): The size of the window function of the savgol filter. Passed directly to savgol. Defaults to 16.
         polynomial_order (int, optional): The order of the polynomial of the savgol filter. Passed directly to savgol. Defaults to 4.
-        median_filter (bool, optional): Apply a median filter to the data before applying the savgol filter using the same window size. Defaults to True. 
+        apply_median_filter (bool, optional): Apply a median filter to the data before applying the savgol filter using the same window size. Defaults to True. 
 
     Returns:
         np.ndarray: Smoothed complex gains
@@ -107,13 +107,13 @@ def smooth_bandpass_complex_gains(
                 data=complex_gains[ant, :, pol].real,
                 window_size=window_size,
                 polynomial_order=polynomial_order,
-                median_filter=median_filter,
+                apply_median_filter=apply_median_filter,
             )
             smoothed_complex_gains[ant, :, pol].imag = smooth_data(
                 data=complex_gains[ant, :, pol].imag,
                 window_size=window_size,
                 polynomial_order=polynomial_order,
-                median_filter=median_filter,
+                apply_median_filter=apply_median_filter,
             )
 
     return smoothed_complex_gains

--- a/flint/bptools/smoother.py
+++ b/flint/bptools/smoother.py
@@ -1,12 +1,15 @@
 import numpy as np
-from scipy.signal import savgol_filter
 from scipy.ndimage import median_filter
+from scipy.signal import savgol_filter
 
 from flint.logging import logger
 
 
 def smooth_data(
-    data: np.ndarray, window_size: int, polynomial_order: int, apply_median_filter: bool = True
+    data: np.ndarray,
+    window_size: int,
+    polynomial_order: int,
+    apply_median_filter: bool = True,
 ) -> np.ndarray:
     """Smooth a 1-dimensional dataset. Internally it uses a savgol filter as
     implemented in scipy.signal.savgol_filter. It is intended to be used to
@@ -18,15 +21,15 @@ def smooth_data(
     datapoints are then remasked with a NaN.
 
     If ``median_filter`` is ``True`` then the raw data (without any interpolation)
-    will first be passed through a median boxcar filter with a window size of 
-    ``window_size``. 
+    will first be passed through a median boxcar filter with a window size of
+    ``window_size``.
 
     Args:
         data (np.ndarray): The 1-dimensional data to be smoothed.
         window_size (int): The size of the window function of the savgol filter. Passed directly to savgol.
         polynomial_order (int): The order of the polynomial of the savgol filter. Passed directly to savgol.
-        apply_median_filter (bool, optional): Apply a median filter to the data before applying the savgol filter using the same window size. Defaults to True. 
-        
+        apply_median_filter (bool, optional): Apply a median filter to the data before applying the savgol filter using the same window size. Defaults to True.
+
     Returns:
         np.ndarray: Smoothed dataset
     """
@@ -60,7 +63,10 @@ def smooth_data(
 
 
 def smooth_bandpass_complex_gains(
-    complex_gains: np.ndarray, window_size: int = 16, polynomial_order: int = 4, apply_median_filter: bool = True
+    complex_gains: np.ndarray,
+    window_size: int = 16,
+    polynomial_order: int = 4,
+    apply_median_filter: bool = True,
 ) -> np.ndarray:
     """Smooth bandpass solutions by applying a savgol filter to the real and imaginary components
     of each of the antenna based polarisation solutions across channels.
@@ -73,14 +79,14 @@ def smooth_bandpass_complex_gains(
     > [ants, chans, pols]
 
     If ``median_filter`` is ``True`` then the raw data (without any interpolation)
-    will first be passed through a median boxcar filter with a window size of 
-    ``window_size``. 
-    
+    will first be passed through a median boxcar filter with a window size of
+    ``window_size``.
+
     Args:
         complex_gains (np.ndarray): Data to be smoothed.
         window_size (int, optional): The size of the window function of the savgol filter. Passed directly to savgol. Defaults to 16.
         polynomial_order (int, optional): The order of the polynomial of the savgol filter. Passed directly to savgol. Defaults to 4.
-        apply_median_filter (bool, optional): Apply a median filter to the data before applying the savgol filter using the same window size. Defaults to True. 
+        apply_median_filter (bool, optional): Apply a median filter to the data before applying the savgol filter using the same window size. Defaults to True.
 
     Returns:
         np.ndarray: Smoothed complex gains

--- a/flint/bptools/smoother.py
+++ b/flint/bptools/smoother.py
@@ -1,11 +1,12 @@
 import numpy as np
 from scipy.signal import savgol_filter
+from scipy.ndimage import median_filter
 
 from flint.logging import logger
 
 
 def smooth_data(
-    data: np.ndarray, window_size: int, polynomial_order: int
+    data: np.ndarray, window_size: int, polynomial_order: int, median_filter: bool = True
 ) -> np.ndarray:
     """Smooth a 1-dimensional dataset. Internally it uses a savgol filter as
     implemented in scipy.signal.savgol_filter. It is intended to be used to
@@ -16,11 +17,16 @@ def smooth_data(
     closest valid data points. Once the savgol filter has been applied these
     datapoints are then remasked with a NaN.
 
+    If ``median_filter`` is ``True`` then the raw data (without any interpolation)
+    will first be passed through a median boxcar filter with a window size of 
+    ``window_size``. 
+
     Args:
         data (np.ndarray): The 1-dimensional data to be smoothed.
         window_size (int): The size of the window function of the savgol filter. Passed directly to savgol.
         polynomial_order (int): The order of the polynomial of the savgol filter. Passed directly to savgol.
-
+        median_filter (bool, optional): Apply a median filter to the data before applying the savgol filter using the same window size. Defaults to True. 
+        
     Returns:
         np.ndarray: Smoothed dataset
     """
@@ -28,6 +34,9 @@ def smooth_data(
     # Make a copy so we do not mess around with the original numpy data
     # where ever it might be. Trust nothing you sea dog.
     data = data.copy()
+
+    if median_filter:
+        data = median_filter(input=data, size=window_size)
 
     # Before we smooth we need to fill in channels that are flagged with nans.
     # For this we will apply a simply linear interpolation across the blanked
@@ -51,7 +60,7 @@ def smooth_data(
 
 
 def smooth_bandpass_complex_gains(
-    complex_gains: np.ndarray, window_size: int = 16, polynomial_order: int = 1
+    complex_gains: np.ndarray, window_size: int = 16, polynomial_order: int = 4, median_filter: bool = True
 ) -> np.ndarray:
     """Smooth bandpass solutions by applying a savgol filter to the real and imaginary components
     of each of the antenna based polarisation solutions across channels.
@@ -63,10 +72,15 @@ def smooth_bandpass_complex_gains(
     The input bandpass data contained by ``complex_gains`` is expected to be in the form:
     > [ants, chans, pols]
 
+    If ``median_filter`` is ``True`` then the raw data (without any interpolation)
+    will first be passed through a median boxcar filter with a window size of 
+    ``window_size``. 
+    
     Args:
         complex_gains (np.ndarray): Data to be smoothed.
         window_size (int, optional): The size of the window function of the savgol filter. Passed directly to savgol. Defaults to 16.
-        polynomial_order (int, optional): The order of the polynomial of the savgol filter. Passed directly to savgol. Defaults to 1.
+        polynomial_order (int, optional): The order of the polynomial of the savgol filter. Passed directly to savgol. Defaults to 4.
+        median_filter (bool, optional): Apply a median filter to the data before applying the savgol filter using the same window size. Defaults to True. 
 
     Returns:
         np.ndarray: Smoothed complex gains
@@ -93,11 +107,13 @@ def smooth_bandpass_complex_gains(
                 data=complex_gains[ant, :, pol].real,
                 window_size=window_size,
                 polynomial_order=polynomial_order,
+                median_filter=median_filter,
             )
             smoothed_complex_gains[ant, :, pol].imag = smooth_data(
                 data=complex_gains[ant, :, pol].imag,
                 window_size=window_size,
                 polynomial_order=polynomial_order,
+                median_filter=median_filter,
             )
 
     return smoothed_complex_gains

--- a/flint/coadd/linmos.py
+++ b/flint/coadd/linmos.py
@@ -12,7 +12,7 @@ from flint.naming import LinmosNames, create_linmos_names, extract_beam_from_nam
 from flint.sclient import run_singularity_command
 
 
-class LinmosCMD(NamedTuple):
+class LinmosCommand(NamedTuple):
     cmd: str
     """The yandasoft linmos task that will be executed"""
     parset: Path
@@ -307,7 +307,7 @@ def linmos_images(
     weight_list: Optional[str] = None,
     holofile: Optional[Path] = None,
     container: Path = Path("yandasoft.sif"),
-) -> LinmosCMD:
+) -> LinmosCommand:
     """Create a linmos parset file and execute it.
 
     Args:
@@ -319,7 +319,7 @@ def linmos_images(
         container (Path, optional): Path to the singularity container that has the yandasoft tools. Defaults to Path('yandasoft.sif').
 
     Returns:
-        LinmosCMD: The linmos command executed and the associated parset file
+        LinmosCommand: The linmos command executed and the associated parset file
     """
 
     assert (
@@ -345,7 +345,7 @@ def linmos_images(
         image=container, command=linmos_cmd_str, bind_dirs=bind_dirs
     )
 
-    linmos_cmd = LinmosCMD(
+    linmos_cmd = LinmosCommand(
         cmd=linmos_cmd_str,
         parset=linmos_parset,
         image_fits=linmos_names.image_fits.absolute(),

--- a/flint/data/aoflagger/ASKAP.lua
+++ b/flint/data/aoflagger/ASKAP.lua
@@ -1,0 +1,142 @@
+--[[
+ This is the default AOFlagger strategy, version 2020-05-26
+ Author: André Offringa
+
+ This strategy is made as generic / easy to tweak as possible, with the most important
+'tweaking' parameters available as variables at the beginning of function 'execute'.
+]]--
+
+aoflagger.require_min_version("3.0")
+
+function execute(input)
+
+  --
+  -- Generic settings
+  --
+
+  -- What polarizations to flag? Default: input:get_polarizations() (=all that are in the input data)
+  -- Other options are e.g.:
+  -- { 'XY', 'YX' } to flag only XY and YX, or
+  -- { 'I', 'Q' } to flag only on Stokes I and Q
+  local flag_polarizations = input:get_polarizations()
+
+  local base_threshold = 1.0  -- lower means more sensitive detection
+  -- How to flag complex values, options are: phase, amplitude, real, imaginary, complex
+  -- May have multiple values to perform detection multiple times
+  local flag_representations = { "amplitude" }
+  local iteration_count = 5  -- how many iterations to perform?
+  local threshold_factor_step = 2.0 -- How much to increase the sensitivity each iteration?
+  -- If the following variable is true, the strategy will consider existing flags
+  -- as bad data. It will exclude flagged data from detection, and make sure that any existing
+  -- flags on input will be flagged on output. If set to false, existing flags are ignored.
+  local exclude_original_flags = false
+  local frequency_resize_factor = 10.0 -- Amount of "extra" smoothing in frequency direction
+  local transient_threshold_factor = 1.5 -- decreasing this value makes detection of transient RFI more aggressive
+ 
+  --
+  -- End of generic settings
+  --
+
+  local inpPolarizations = input:get_polarizations()
+
+  if(not exclude_original_flags) then
+    input:clear_mask()
+  end
+  -- For collecting statistics. Note that this is done after clear_mask(),
+  -- so that the statistics ignore any flags in the input data. 
+  local copy_of_input = input:copy()
+  
+  for ipol,polarization in ipairs(flag_polarizations) do
+ 
+    local pol_data = input:convert_to_polarization(polarization)
+
+    for _,representation in ipairs(flag_representations) do
+
+      data = pol_data:convert_to_complex(representation)
+      local original_data = data:copy()
+
+      for i=1,iteration_count-1 do
+        local threshold_factor = math.pow(threshold_factor_step, iteration_count-i)
+
+        local sumthr_level = threshold_factor * base_threshold
+        if(exclude_original_flags) then
+          aoflagger.sumthreshold_masked(data, original_data, sumthr_level, sumthr_level*transient_threshold_factor, true, true)
+        else
+          aoflagger.sumthreshold(data, sumthr_level, sumthr_level*transient_threshold_factor, true, true)
+        end
+
+        -- Do timestep & channel flagging
+        local chdata = data:copy()
+        aoflagger.threshold_timestep_rms(data, 3.5)
+        aoflagger.threshold_channel_rms(chdata, 3.0 * threshold_factor, true)
+        data:join_mask(chdata)
+
+        -- High pass filtering steps
+        data:set_visibilities(original_data)
+        if(exclude_original_flags) then
+          data:join_mask(original_data)
+        end
+
+        local resized_data = aoflagger.downsample(data, 3, frequency_resize_factor, true)
+        aoflagger.low_pass_filter(resized_data, 21, 31, 2.5, 5.0)
+        aoflagger.upsample(resized_data, data, 3, frequency_resize_factor)
+
+        -- In case this script is run from inside rfigui, calling
+        -- the following visualize function will add the current result
+        -- to the list of displayable visualizations.
+        -- If the script is not running inside rfigui, the call is ignored.
+        aoflagger.visualize(data, "Fit #"..i, i-1)
+
+        local tmp = original_data - data
+        tmp:set_mask(data)
+        data = tmp
+
+        aoflagger.visualize(data, "Residual #"..i, i+iteration_count)
+        aoflagger.set_progress((ipol-1)*iteration_count+i, #flag_polarizations*iteration_count )
+      end -- end of iterations
+
+      if(exclude_original_flags) then
+        aoflagger.sumthreshold_masked(data, original_data, base_threshold, base_threshold*transient_threshold_factor, true, true)
+      else
+        aoflagger.sumthreshold(data, base_threshold, base_threshold*transient_threshold_factor, true, true)
+      end
+    end -- end of complex representation iteration
+
+    -- Helper function used in the strategy
+    function contains(arr, val)
+      for _,v in ipairs(arr) do
+        if v == val then return true end
+      end
+      return false
+    end
+
+    if contains(inpPolarizations, polarization) then
+      if input:is_complex() then
+        data = data:convert_to_complex("complex")
+      end
+      input:set_polarization_data(polarization, data)
+    else
+      input:join_mask(data)
+    end
+
+    aoflagger.visualize(data, "Residual #"..iteration_count, 2*iteration_count)
+    aoflagger.set_progress(ipol, #flag_polarizations )
+  end -- end of polarization iterations
+
+  if(exclude_original_flags) then
+    aoflagger.scale_invariant_rank_operator_masked(input, copy_of_input, 0.2, 0.2)
+  else
+    aoflagger.scale_invariant_rank_operator(input, 0.2, 0.2)
+  end
+
+  aoflagger.threshold_timestep_rms(input, 4.0)
+
+  if input:is_complex() and input:has_metadata() then
+    -- This command will calculate a few statistics like flag% and stddev over
+    -- time, frequency and baseline and write those to the MS. These can be
+    -- visualized with aoqplot.
+    aoflagger.collect_statistics(input, copy_of_input)
+  end
+  input:flag_nans()
+end
+

--- a/flint/data/aoflagger/ASKAP.lua
+++ b/flint/data/aoflagger/ASKAP.lua
@@ -32,7 +32,7 @@ function execute(input)
   local exclude_original_flags = false
   local frequency_resize_factor = 40.0 -- Amount of "extra" smoothing in frequency direction
   local transient_threshold_factor = 1.0 -- decreasing this value makes detection of transient RFI more aggressive
- 
+
   --
   -- End of generic settings
   --
@@ -43,11 +43,11 @@ function execute(input)
     input:clear_mask()
   end
   -- For collecting statistics. Note that this is done after clear_mask(),
-  -- so that the statistics ignore any flags in the input data. 
+  -- so that the statistics ignore any flags in the input data.
   local copy_of_input = input:copy()
-  
+
   for ipol,polarization in ipairs(flag_polarizations) do
- 
+
     local pol_data = input:convert_to_polarization(polarization)
 
     for _,representation in ipairs(flag_representations) do
@@ -139,4 +139,3 @@ function execute(input)
   end
   input:flag_nans()
 end
-

--- a/flint/data/aoflagger/ASKAP.lua
+++ b/flint/data/aoflagger/ASKAP.lua
@@ -24,14 +24,14 @@ function execute(input)
   -- How to flag complex values, options are: phase, amplitude, real, imaginary, complex
   -- May have multiple values to perform detection multiple times
   local flag_representations = { "amplitude" }
-  local iteration_count = 5  -- how many iterations to perform?
+  local iteration_count = 3  -- how many iterations to perform?
   local threshold_factor_step = 2.0 -- How much to increase the sensitivity each iteration?
   -- If the following variable is true, the strategy will consider existing flags
   -- as bad data. It will exclude flagged data from detection, and make sure that any existing
   -- flags on input will be flagged on output. If set to false, existing flags are ignored.
   local exclude_original_flags = false
-  local frequency_resize_factor = 10.0 -- Amount of "extra" smoothing in frequency direction
-  local transient_threshold_factor = 1.5 -- decreasing this value makes detection of transient RFI more aggressive
+  local frequency_resize_factor = 40.0 -- Amount of "extra" smoothing in frequency direction
+  local transient_threshold_factor = 40.0 -- decreasing this value makes detection of transient RFI more aggressive
  
   --
   -- End of generic settings

--- a/flint/data/aoflagger/ASKAP.lua
+++ b/flint/data/aoflagger/ASKAP.lua
@@ -31,7 +31,7 @@ function execute(input)
   -- flags on input will be flagged on output. If set to false, existing flags are ignored.
   local exclude_original_flags = false
   local frequency_resize_factor = 40.0 -- Amount of "extra" smoothing in frequency direction
-  local transient_threshold_factor = 40.0 -- decreasing this value makes detection of transient RFI more aggressive
+  local transient_threshold_factor = 1.0 -- decreasing this value makes detection of transient RFI more aggressive
  
   --
   -- End of generic settings

--- a/flint/data/aoflagger/ATCA.lua
+++ b/flint/data/aoflagger/ATCA.lua
@@ -1,0 +1,142 @@
+--[[
+ This is the default AOFlagger strategy, version 2020-05-26
+ Author: André Offringa
+
+ This strategy is made as generic / easy to tweak as possible, with the most important
+'tweaking' parameters available as variables at the beginning of function 'execute'.
+]]--
+
+aoflagger.require_min_version("3.0")
+
+function execute(input)
+
+  --
+  -- Generic settings
+  --
+
+  -- What polarizations to flag? Default: input:get_polarizations() (=all that are in the input data)
+  -- Other options are e.g.:
+  -- { 'XY', 'YX' } to flag only XY and YX, or
+  -- { 'I', 'Q' } to flag only on Stokes I and Q
+  local flag_polarizations = input:get_polarizations()
+
+  local base_threshold = 1.0  -- lower means more sensitive detection
+  -- How to flag complex values, options are: phase, amplitude, real, imaginary, complex
+  -- May have multiple values to perform detection multiple times
+  local flag_representations = { "amplitude" }
+  local iteration_count = 3  -- how many iterations to perform?
+  local threshold_factor_step = 2.0 -- How much to increase the sensitivity each iteration?
+  -- If the following variable is true, the strategy will consider existing flags
+  -- as bad data. It will exclude flagged data from detection, and make sure that any existing
+  -- flags on input will be flagged on output. If set to false, existing flags are ignored.
+  local exclude_original_flags = false
+  local frequency_resize_factor = 1.0 -- Amount of "extra" smoothing in frequency direction
+  local transient_threshold_factor = 1.0 -- decreasing this value makes detection of transient RFI more aggressive
+ 
+  --
+  -- End of generic settings
+  --
+
+  local inpPolarizations = input:get_polarizations()
+
+  if(not exclude_original_flags) then
+    input:clear_mask()
+  end
+  -- For collecting statistics. Note that this is done after clear_mask(),
+  -- so that the statistics ignore any flags in the input data. 
+  local copy_of_input = input:copy()
+  
+  for ipol,polarization in ipairs(flag_polarizations) do
+ 
+    local pol_data = input:convert_to_polarization(polarization)
+
+    for _,representation in ipairs(flag_representations) do
+
+      data = pol_data:convert_to_complex(representation)
+      local original_data = data:copy()
+
+      for i=1,iteration_count-1 do
+        local threshold_factor = math.pow(threshold_factor_step, iteration_count-i)
+
+        local sumthr_level = threshold_factor * base_threshold
+        if(exclude_original_flags) then
+          aoflagger.sumthreshold_masked(data, original_data, sumthr_level, sumthr_level*transient_threshold_factor, true, true)
+        else
+          aoflagger.sumthreshold(data, sumthr_level, sumthr_level*transient_threshold_factor, true, true)
+        end
+
+        -- Do timestep & channel flagging
+        local chdata = data:copy()
+        aoflagger.threshold_timestep_rms(data, 3.5)
+        aoflagger.threshold_channel_rms(chdata, 3.0 * threshold_factor, true)
+        data:join_mask(chdata)
+
+        -- High pass filtering steps
+        data:set_visibilities(original_data)
+        if(exclude_original_flags) then
+          data:join_mask(original_data)
+        end
+
+        local resized_data = aoflagger.downsample(data, 3, frequency_resize_factor, true)
+        aoflagger.low_pass_filter(resized_data, 21, 31, 2.5, 5.0)
+        aoflagger.upsample(resized_data, data, 3, frequency_resize_factor)
+
+        -- In case this script is run from inside rfigui, calling
+        -- the following visualize function will add the current result
+        -- to the list of displayable visualizations.
+        -- If the script is not running inside rfigui, the call is ignored.
+        aoflagger.visualize(data, "Fit #"..i, i-1)
+
+        local tmp = original_data - data
+        tmp:set_mask(data)
+        data = tmp
+
+        aoflagger.visualize(data, "Residual #"..i, i+iteration_count)
+        aoflagger.set_progress((ipol-1)*iteration_count+i, #flag_polarizations*iteration_count )
+      end -- end of iterations
+
+      if(exclude_original_flags) then
+        aoflagger.sumthreshold_masked(data, original_data, base_threshold, base_threshold*transient_threshold_factor, true, true)
+      else
+        aoflagger.sumthreshold(data, base_threshold, base_threshold*transient_threshold_factor, true, true)
+      end
+    end -- end of complex representation iteration
+
+    -- Helper function used in the strategy
+    function contains(arr, val)
+      for _,v in ipairs(arr) do
+        if v == val then return true end
+      end
+      return false
+    end
+
+    if contains(inpPolarizations, polarization) then
+      if input:is_complex() then
+        data = data:convert_to_complex("complex")
+      end
+      input:set_polarization_data(polarization, data)
+    else
+      input:join_mask(data)
+    end
+
+    aoflagger.visualize(data, "Residual #"..iteration_count, 2*iteration_count)
+    aoflagger.set_progress(ipol, #flag_polarizations )
+  end -- end of polarization iterations
+
+  if(exclude_original_flags) then
+    aoflagger.scale_invariant_rank_operator_masked(input, copy_of_input, 0.2, 0.2)
+  else
+    aoflagger.scale_invariant_rank_operator(input, 0.2, 0.2)
+  end
+
+  aoflagger.threshold_timestep_rms(input, 4.0)
+
+  if input:is_complex() and input:has_metadata() then
+    -- This command will calculate a few statistics like flag% and stddev over
+    -- time, frequency and baseline and write those to the MS. These can be
+    -- visualized with aoqplot.
+    aoflagger.collect_statistics(input, copy_of_input)
+  end
+  input:flag_nans()
+end
+

--- a/flint/data/aoflagger/ATCA.lua
+++ b/flint/data/aoflagger/ATCA.lua
@@ -32,7 +32,7 @@ function execute(input)
   local exclude_original_flags = false
   local frequency_resize_factor = 1.0 -- Amount of "extra" smoothing in frequency direction
   local transient_threshold_factor = 1.0 -- decreasing this value makes detection of transient RFI more aggressive
- 
+
   --
   -- End of generic settings
   --
@@ -43,11 +43,11 @@ function execute(input)
     input:clear_mask()
   end
   -- For collecting statistics. Note that this is done after clear_mask(),
-  -- so that the statistics ignore any flags in the input data. 
+  -- so that the statistics ignore any flags in the input data.
   local copy_of_input = input:copy()
-  
+
   for ipol,polarization in ipairs(flag_polarizations) do
- 
+
     local pol_data = input:convert_to_polarization(polarization)
 
     for _,representation in ipairs(flag_representations) do
@@ -139,4 +139,3 @@ function execute(input)
   end
   input:flag_nans()
 end
-

--- a/flint/flagging.py
+++ b/flint/flagging.py
@@ -5,6 +5,7 @@ from argparse import ArgumentParser
 from pathlib import Path
 from typing import Collection, NamedTuple, Optional, Union
 
+import pkg_resources
 import numpy as np
 from casacore.tables import table
 
@@ -127,7 +128,10 @@ def create_aoflagger_cmd(ms: MS) -> AOFlaggerCommand:
     if not check_column_in_ms(ms):
         raise MSError(f"Column {ms.column} not found in {ms.path}.")
 
-    cmd = f"aoflagger -column {ms.column} -v {str(ms.path.absolute())}"
+    flagging_strategy = pkg_resources.resource_filename("flint", "data/aoflagger/ATCA.lua")
+    logger.info(f"Flagging using the stategy file {flagging_strategy}")
+
+    cmd = f"aoflagger -column {ms.column} -strategy {flagging_strategy} -v {str(ms.path.absolute())}"
 
     return AOFlaggerCommand(cmd=cmd, ms_path=ms.path)
 

--- a/flint/flagging.py
+++ b/flint/flagging.py
@@ -5,8 +5,8 @@ from argparse import ArgumentParser
 from pathlib import Path
 from typing import Collection, NamedTuple, Optional, Union
 
-import pkg_resources
 import numpy as np
+import pkg_resources
 from casacore.tables import table
 
 from flint.exceptions import MSError
@@ -22,8 +22,9 @@ class AOFlaggerCommand(NamedTuple):
     """The command that will be executed"""
     ms_path: Path
     """The path to the MS that will be flagged. """
-    strategy_file: Optional[Path] = None 
+    strategy_file: Optional[Path] = None
     """The path to the aoflagging stategy file to use"""
+
 
 def nan_zero_extreme_flag_ms(
     ms: Union[Path, MS],
@@ -129,12 +130,16 @@ def create_aoflagger_cmd(ms: MS) -> AOFlaggerCommand:
     if not check_column_in_ms(ms):
         raise MSError(f"Column {ms.column} not found in {ms.path}.")
 
-    flagging_strategy = pkg_resources.resource_filename("flint", "data/aoflagger/ATCA.lua")
+    flagging_strategy = pkg_resources.resource_filename(
+        "flint", "data/aoflagger/ATCA.lua"
+    )
     logger.info(f"Flagging using the stategy file {flagging_strategy}")
 
     cmd = f"aoflagger -column {ms.column} -strategy {flagging_strategy} -v {str(ms.path.absolute())}"
 
-    return AOFlaggerCommand(cmd=cmd, ms_path=ms.path, strategy_file=Path(flagging_strategy))
+    return AOFlaggerCommand(
+        cmd=cmd, ms_path=ms.path, strategy_file=Path(flagging_strategy)
+    )
 
 
 def run_aoflagger_cmd(aoflagger_cmd: AOFlaggerCommand, container: Path) -> None:

--- a/flint/flagging.py
+++ b/flint/flagging.py
@@ -129,7 +129,7 @@ def create_aoflagger_cmd(ms: MS) -> AOFlaggerCommand:
     if not check_column_in_ms(ms):
         raise MSError(f"Column {ms.column} not found in {ms.path}.")
 
-    flagging_strategy = pkg_resources.resource_filename("flint", "data/aoflagger/ATCA.lua")
+    flagging_strategy = pkg_resources.resource_filename("flint", "data/aoflagger/ASKAP.lua")
     logger.info(f"Flagging using the stategy file {flagging_strategy}")
 
     cmd = f"aoflagger -column {ms.column} -strategy {flagging_strategy} -v {str(ms.path.absolute())}"

--- a/flint/flagging.py
+++ b/flint/flagging.py
@@ -22,7 +22,8 @@ class AOFlaggerCommand(NamedTuple):
     """The command that will be executed"""
     ms_path: Path
     """The path to the MS that will be flagged. """
-
+    strategy_file: Optional[Path] = None 
+    """The path to the aoflagging stategy file to use"""
 
 def nan_zero_extreme_flag_ms(
     ms: Union[Path, MS],
@@ -133,7 +134,7 @@ def create_aoflagger_cmd(ms: MS) -> AOFlaggerCommand:
 
     cmd = f"aoflagger -column {ms.column} -strategy {flagging_strategy} -v {str(ms.path.absolute())}"
 
-    return AOFlaggerCommand(cmd=cmd, ms_path=ms.path)
+    return AOFlaggerCommand(cmd=cmd, ms_path=ms.path, strategy_file=Path(flagging_strategy))
 
 
 def run_aoflagger_cmd(aoflagger_cmd: AOFlaggerCommand, container: Path) -> None:
@@ -149,6 +150,9 @@ def run_aoflagger_cmd(aoflagger_cmd: AOFlaggerCommand, container: Path) -> None:
 
     bind_dirs = [aoflagger_cmd.ms_path.parent.absolute()]
     logger.debug(f"Bind directory for aoflagger: {bind_dirs}")
+
+    if aoflagger_cmd.strategy_file:
+        bind_dirs.append(aoflagger_cmd.strategy_file)
 
     run_singularity_command(
         image=container.absolute(), command=aoflagger_cmd.cmd, bind_dirs=bind_dirs

--- a/flint/flagging.py
+++ b/flint/flagging.py
@@ -129,7 +129,7 @@ def create_aoflagger_cmd(ms: MS) -> AOFlaggerCommand:
     if not check_column_in_ms(ms):
         raise MSError(f"Column {ms.column} not found in {ms.path}.")
 
-    flagging_strategy = pkg_resources.resource_filename("flint", "data/aoflagger/ASKAP.lua")
+    flagging_strategy = pkg_resources.resource_filename("flint", "data/aoflagger/ATCA.lua")
     logger.info(f"Flagging using the stategy file {flagging_strategy}")
 
     cmd = f"aoflagger -column {ms.column} -strategy {flagging_strategy} -v {str(ms.path.absolute())}"

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -114,7 +114,7 @@ class WSCleanOptions(NamedTuple):
         return WSCleanOptions(**_dict)
 
 
-class WSCleanCMD(NamedTuple):
+class WSCleanCommand(NamedTuple):
     """Simple container for a wsclean command."""
 
     cmd: str
@@ -128,11 +128,11 @@ class WSCleanCMD(NamedTuple):
     cleanup: bool = True
     """Will clean up the dirty images/psfs/residuals/models when the imaging has completed"""
 
-    def with_options(self, **kwargs) -> WSCleanCMD:
+    def with_options(self, **kwargs) -> WSCleanCommand:
         _dict = self._asdict()
         _dict.update(**kwargs)
 
-        return WSCleanCMD(**_dict)
+        return WSCleanCommand(**_dict)
 
 
 def get_wsclean_output_names(
@@ -250,7 +250,7 @@ def delete_wsclean_outputs(
 
 def create_wsclean_cmd(
     ms: MS, wsclean_options: WSCleanOptions, container: Optional[Path] = None
-) -> WSCleanCMD:
+) -> WSCleanCommand:
     """Create a wsclean command from a WSCleanOptions container
 
     Args:
@@ -262,7 +262,7 @@ def create_wsclean_cmd(
         ValueError: Raised when a option has not been successfully processed
 
     Returns:
-        WSCleanCMD: The wsclean command to run
+        WSCleanCommand: The wsclean command to run
     """
     # Some wsclean options, if multiple values are provided, might need
     # to be join as a csv list. Others might want to be dumped in. Just
@@ -309,7 +309,7 @@ def create_wsclean_cmd(
 
     logger.info(f"Constructed wsclean command: {cmd=}")
     logger.info("Setting default model data column to 'MODEL_DATA'")
-    wsclean_cmd = WSCleanCMD(
+    wsclean_cmd = WSCleanCommand(
         cmd=cmd, options=wsclean_options, ms=ms.with_options(model_column="MODEL_DATA")
     )
 
@@ -319,16 +319,16 @@ def create_wsclean_cmd(
     return wsclean_cmd
 
 
-def run_wsclean_imager(wsclean_cmd: WSCleanCMD, container: Path) -> WSCleanCMD:
+def run_wsclean_imager(wsclean_cmd: WSCleanCommand, container: Path) -> WSCleanCommand:
     """Run a provided wsclean command. Optionally will clean up files,
     including the dirty beams, psfs and other assorted things.
 
     Args:
-        wsclean_cmd (WSCleanCMD): The command to run, and other properties (cleanup.)
+        wsclean_cmd (WSCleanCommand): The command to run, and other properties (cleanup.)
         container (Path): Path to the container with wsclean available in it
 
     Returns:
-        WSCleanCMD: The executed wsclean command with a populated imageset properter.
+        WSCleanCommand: The executed wsclean command with a populated imageset properter.
     """
 
     ms = wsclean_cmd.ms
@@ -372,7 +372,7 @@ def wsclean_imager(
     wsclean_container: Path,
     wsclean_options_path: Optional[Path] = None,
     update_wsclean_options: Optional[Dict[str, Any]] = None,
-) -> WSCleanCMD:
+) -> WSCleanCommand:
     """Create and run a wsclean imager command against a measurement set.
 
     Args:
@@ -381,7 +381,7 @@ def wsclean_imager(
         wsclean_options_path (Optional[Path], optional): Location of a wsclean set of options. Defaults to None.
 
     Returns:
-        WSCleanCMD: _description_
+        WSCleanCommand: _description_
     """
 
     # TODO: This should be expanded to support multiple measurement sets
@@ -427,7 +427,7 @@ def create_template_wsclean_options(
         WSCleanOptions: Template options to use for the wsclean fits header creation
     """
 
-    temmplate_options = WSCleanCMD(
+    temmplate_options = WSCleanCommand(
         size=input_wsclean_options.size,
         channels_out=1,
         nmiter=0,

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -34,7 +34,6 @@ from flint.validation import create_validation_plot
 
 # These are simple task wrapped functions and require no other modification
 task_preprocess_askap_ms = task(preprocess_askap_ms)
-task_flag_ms_aoflagger = task(flag_ms_aoflagger)
 task_split_by_field = task(split_by_field)
 task_select_solution_for_ms = task(select_aosolution_for_ms)
 task_create_apply_solutions_cmd = task(create_apply_solutions_cmd)
@@ -46,7 +45,7 @@ task_create_apply_solutions_cmd = task(create_apply_solutions_cmd)
 FlagMS = TypeVar("FlagMS", MS, ApplySolutions)
 
 @task
-def task_flag_ms_aoflagger2(ms: FlagMS, container: Path, rounds: int = 1) -> FlagMS:
+def task_flag_ms_aoflagger(ms: FlagMS, container: Path, rounds: int = 1) -> FlagMS:
     extracted_ms = ms.ms if isinstance(ms, ApplySolutions) else ms 
     
     extracted_ms = flag_ms_aoflagger(ms=extracted_ms, container=container, rounds=rounds)

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -5,7 +5,7 @@ imaging flows.
 """
 
 from pathlib import Path
-from typing import Any, Collection, Dict, List, Optional, Union, TypeVar
+from typing import Any, Collection, Dict, List, Optional, TypeVar, Union
 
 from prefect import task
 
@@ -44,13 +44,17 @@ task_create_apply_solutions_cmd = task(create_apply_solutions_cmd)
 
 FlagMS = TypeVar("FlagMS", MS, ApplySolutions)
 
+
 @task
 def task_flag_ms_aoflagger(ms: FlagMS, container: Path, rounds: int = 1) -> FlagMS:
-    extracted_ms = ms.ms if isinstance(ms, ApplySolutions) else ms 
-    
-    extracted_ms = flag_ms_aoflagger(ms=extracted_ms, container=container, rounds=rounds)
+    extracted_ms = ms.ms if isinstance(ms, ApplySolutions) else ms
+
+    extracted_ms = flag_ms_aoflagger(
+        ms=extracted_ms, container=container, rounds=rounds
+    )
 
     return ms
+
 
 @task
 def task_bandpass_create_apply_solutions_cmd(

--- a/flint/prefect/flows/bandpass_pipeline.py
+++ b/flint/prefect/flows/bandpass_pipeline.py
@@ -91,7 +91,7 @@ def task_flag_solutions(calibrate_cmd: CalibrateCommand) -> CalibrateCommand:
             )
 
     flagged_solutions_path = flag_aosolutions(
-        solutions_path=solution_path, ref_ant=0, flag_cut=3, plot_dir=plot_dir
+        solutions_path=solution_path, ref_ant=-1, flag_cut=3, plot_dir=plot_dir, smooth_solutions=True
     )
 
     return calibrate_cmd.with_options(

--- a/flint/prefect/flows/bandpass_pipeline.py
+++ b/flint/prefect/flows/bandpass_pipeline.py
@@ -91,7 +91,11 @@ def task_flag_solutions(calibrate_cmd: CalibrateCommand) -> CalibrateCommand:
             )
 
     flagged_solutions_path = flag_aosolutions(
-        solutions_path=solution_path, ref_ant=-1, flag_cut=3, plot_dir=plot_dir, smooth_solutions=True
+        solutions_path=solution_path,
+        ref_ant=-1,
+        flag_cut=3,
+        plot_dir=plot_dir,
+        smooth_solutions=True,
     )
 
     return calibrate_cmd.with_options(

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -80,7 +80,7 @@ def process_science_fields(
     # other calibration strategies get added
     # Scan the existing bandpass directory for the existing solutions
     calibrate_cmds = find_existing_solutions(
-        bandpass_directory=bandpass_path, use_preflagged=True, use_smoothed=False
+        bandpass_directory=bandpass_path, use_preflagged=True, use_smoothed=True
     )
 
     logger.info(f"Constructed the following {calibrate_cmds=}")

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -20,7 +20,6 @@ from flint.prefect.common.imaging import (
     task_create_apply_solutions_cmd,
     task_create_validation_plot,
     task_flag_ms_aoflagger,
-    task_flag_ms_aoflagger2,
     task_gaincal_applycal_ms,
     task_get_common_beam,
     task_linmos_images,
@@ -101,10 +100,6 @@ def process_science_fields(
         instrument_column=unmapped("INSTRUMENT_DATA"),
         overwrite=True,
     )
-    # # TODO: Flag after applyng solutions
-    # flag_field_mss = task_flag_ms_aoflagger.map(
-    #     ms=preprocess_science_mss, container=flagger_container, rounds=1
-    # )
     solutions_paths = task_select_solution_for_ms.map(
         calibrate_cmds=unmapped(calibrate_cmds), ms=preprocess_science_mss
     )
@@ -114,7 +109,7 @@ def process_science_fields(
         container=calibrate_container,
     )
 
-    flagged_mss = task_flag_ms_aoflagger2.map(
+    flagged_mss = task_flag_ms_aoflagger.map(
         ms=apply_solutions_cmds, container=flagger_container, rounds=1
     )
 

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -124,7 +124,7 @@ def process_science_fields(
     wsclean_init = {
         "size": 7144,
         "minuv_l": 235,
-        "weight": "briggs 0.5",
+        "weight": "briggs -0.5",
         "auto_mask": 5,
         "multiscale": True,
         "local_rms_window": 55,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ include = [
     {path = 'flint/data/model/1934-638.calibrate.txt'},
     {path = 'flint/data/source_counts/de_zotti_1p4.txt'},
     {path = 'flint/data/source_counts/SKADS_1p4GHz.fits'},
+    {path = 'flint/data/aoflagger/ATCA.lua'},
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
When inspecting some of the bandpass solutions obtained through `calibrate` it seems like there is a some RFI still present in the data. This change has:
- a median box car filter that is applied to the real and imaginary components of the complex gains of the bandpass solution
- increased the polynomial order of the smoothing filter
- added the beginnings of an aoflagger strategy other than its generic mode
- reordered when aoflagger is applied to the science data. It now runs after the bandpass has been applied, not before. 