### PR TITLE
Create a linmos image from residual images

### DIFF
--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -150,16 +150,16 @@ def get_wsclean_output_names(
         "model",
         "psf",
     ),
-    check_exists_when_adding: bool = False
+    check_exists_when_adding: bool = False,
 ) -> ImageSet:
     """Attempt to generate the file names and paths that would be
     created by an imaging run of wsclean. This is done using a the
-    known (expected) naming format of modern wsclean versions. 
-    
-    Checks can be made to ensure a file exists before adding it 
+    known (expected) naming format of modern wsclean versions.
+
+    Checks can be made to ensure a file exists before adding it
     to the output ``ImageSet``. This might be important as some
     wsclean image products might be deleted in order to preserve
-    disk space. 
+    disk space.
 
     Args:
         prefix (str): The prefix of the imaging run (the -name option in wsclean call)
@@ -168,7 +168,7 @@ def get_wsclean_output_names(
         verify_exists (bool, optional): Ensures that each generated path corresponds to an actual file. Defaults to False.
         include_mfs (bool, optional): Include the MFS images produced by wsclean. Defaults to True.
         output_types (Union[str,Collection[str]]): Include files of this type, including image, dirty, residual, model, psf. Defaults to  ('image','dirty','residual','model', 'psf').
-        check_exists_when_adding (bool, optional): Only add a generated file if it exists. Although related to the ``verify_exists``, when this optional is ``True`` files will silently be ignored if they are not found. if this and ``verify_exists`` are both ``True`` then no errors on missing files will be raised. Defaults to False. 
+        check_exists_when_adding (bool, optional): Only add a generated file if it exists. Although related to the ``verify_exists``, when this optional is ``True`` files will silently be ignored if they are not found. if this and ``verify_exists`` are both ``True`` then no errors on missing files will be raised. Defaults to False.
 
     Raises:
         FileExistsError: Raised when a file does not exist and verify_exists is True.
@@ -207,8 +207,8 @@ def get_wsclean_output_names(
 
                 if check_exists_when_adding and not Path(path_str).exists():
                     logger.debug(f"{path_str} does not existing. Not adding. ")
-                    continue 
-                
+                    continue
+
                 paths.append(Path(path_str))
 
         images[image_type] = paths
@@ -223,7 +223,6 @@ def get_wsclean_output_names(
             psf_images = [psf_image for psf_image in psf_images if psf_image.exists()]
 
         images["psf"] = psf_images
-
 
     if verify_exists:
         paths_no_exists: List[Path] = []
@@ -382,7 +381,7 @@ def run_wsclean_imager(wsclean_cmd: WSCleanCommand, container: Path) -> WSCleanC
         subbands=wsclean_cmd.options.channels_out,
         verify_exists=True,
         output_types=("image", "residual"),
-        check_exists_when_adding=True
+        check_exists_when_adding=True,
     )
 
     logger.info(f"Found {imageset.image=}")

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -384,7 +384,7 @@ def run_wsclean_imager(wsclean_cmd: WSCleanCommand, container: Path) -> WSCleanC
         check_exists_when_adding=True,
     )
 
-    logger.info(f"Found {imageset.image=}")
+    logger.info(f"Constructed {imageset=}")
 
     return wsclean_cmd.with_options(imageset=imageset)
 

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -361,7 +361,7 @@ def run_wsclean_imager(wsclean_cmd: WSCleanCommand, container: Path) -> WSCleanC
         prefix=prefix,
         subbands=wsclean_cmd.options.channels_out,
         verify_exists=True,
-        output_types="image",
+        output_types=("image", "residual")
     )
 
     logger.info(f"Found {imageset.image=}")

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -150,9 +150,16 @@ def get_wsclean_output_names(
         "model",
         "psf",
     ),
+    check_exists_when_adding: bool = False
 ) -> ImageSet:
     """Attempt to generate the file names and paths that would be
-    created by an imaging run of wsclean.
+    created by an imaging run of wsclean. This is done using a the
+    known (expected) naming format of modern wsclean versions. 
+    
+    Checks can be made to ensure a file exists before adding it 
+    to the output ``ImageSet``. This might be important as some
+    wsclean image products might be deleted in order to preserve
+    disk space. 
 
     Args:
         prefix (str): The prefix of the imaging run (the -name option in wsclean call)
@@ -161,6 +168,7 @@ def get_wsclean_output_names(
         verify_exists (bool, optional): Ensures that each generated path corresponds to an actual file. Defaults to False.
         include_mfs (bool, optional): Include the MFS images produced by wsclean. Defaults to True.
         output_types (Union[str,Collection[str]]): Include files of this type, including image, dirty, residual, model, psf. Defaults to  ('image','dirty','residual','model', 'psf').
+        check_exists_when_adding (bool, optional): Only add a generated file if it exists. Although related to the ``verify_exists``, when this optional is ``True`` files will silently be ignored if they are not found. if this and ``verify_exists`` are both ``True`` then no errors on missing files will be raised. Defaults to False. 
 
     Raises:
         FileExistsError: Raised when a file does not exist and verify_exists is True.
@@ -178,6 +186,8 @@ def get_wsclean_output_names(
         in_pols = (None,)
     elif isinstance(pols, str):
         in_pols = (pols,)
+    else:
+        in_pols = pols
 
     if isinstance(output_types, str):
         output_types = (output_types,)
@@ -195,15 +205,25 @@ def get_wsclean_output_names(
                 else:
                     path_str = f"{prefix}-{subband_str}-{image_type}.fits"
 
+                if check_exists_when_adding and not Path(path_str).exists():
+                    logger.debug(f"{path_str} does not existing. Not adding. ")
+                    continue 
+                
                 paths.append(Path(path_str))
 
         images[image_type] = paths
 
     # The PSF is the same for all stokes
     if "psf" in output_types:
-        images["psf"] = [
+        psf_images = [
             Path(f"{prefix}-{subband_str}-psf.fits") for subband_str in subband_strs
         ]
+        # Filter out files if they do not exists
+        if check_exists_when_adding:
+            psf_images = [psf_image for psf_image in psf_images if psf_image.exists()]
+
+        images["psf"] = psf_images
+
 
     if verify_exists:
         paths_no_exists: List[Path] = []

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -381,7 +381,8 @@ def run_wsclean_imager(wsclean_cmd: WSCleanCommand, container: Path) -> WSCleanC
         prefix=prefix,
         subbands=wsclean_cmd.options.channels_out,
         verify_exists=True,
-        output_types=("image", "residual")
+        output_types=("image", "residual"),
+        check_exists_when_adding=True
     )
 
     logger.info(f"Found {imageset.image=}")

--- a/flint/options.py
+++ b/flint/options.py
@@ -45,3 +45,5 @@ class FieldOptions(NamedTuple):
     """Path to the directory container the refernce catalogues, used to generate valiation plots"""
     butterworth_filter: bool = False
     """Whether a Butterworth filter should be used when constructing the clean mask"""
+    linmos_residuals: bool = False
+    """Linmos the cleaning residuals together into a field image"""

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -273,7 +273,7 @@ def task_convolve_image(
         cutoff (float, optional): Maximum major beam axis an image is allowed to have before it will not be convolved. Defaults to 60.
 
     Returns:
-        Collection[Path]: Path to the output images that have been convolved
+        Collection[Path]: Path to the output images that have been convolved. 
     """
     assert (
         wsclean_cmd.imageset is not None
@@ -284,9 +284,18 @@ def task_convolve_image(
         mode in supported_modes
     ), f"{mode=} is not supported. Known modes are {supported_modes}"
 
-    logger.info(f"EWxtracting {mode}")
-    image_paths: Collection[Path] = wsclean_cmd.imageset.__dict__.get(mode)
-
+    logger.info(f"Extracting {mode}")
+    image_paths: Collection[Path] = (
+        wsclean_cmd.imageset.image if mode == "image" else  wsclean_cmd.imageset.residual
+    )
+    
+    # It is possible depending on how aggressively cleaning image products are deleted that these
+    # some cleaning products (e.g. residuals) do not exist. There are a number of ways one could consider
+    # handling this. The pirate in me feels like less is more, so an error will be enough. Keeping
+    # things simple and avoiding the problem is probably the better way of dealing with this 
+    # situation. In time this would mean that we inspect and handle conflicting pipeline options. 
+    assert image_paths is not None, f"{image_paths=} for {mode=} and {wsclean_cmd.imageset=}"
+    
     logger.info(f"Will convolve {image_paths}")
 
     # experience has shown that astropy units do not always work correctly

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -397,7 +397,7 @@ def _convolve_linmos_residuals(
     field_options: FieldOptions,
 ) -> LinmosCommand:
     """An internal function that launches the convolution to a common resolution
-    and subsequent linmos of the wsclean residual images. 
+    and subsequent linmos of the wsclean residual images.
 
     Args:
         wsclean_cmds (Collection[WSCleanCommand]): Collection of wsclean imaging results, with residual images described in the attached ``ImageSet``

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -27,11 +27,11 @@ from flint.masking import (
 )
 from flint.ms import MS, preprocess_askap_ms, split_by_field
 from flint.naming import FITSMaskNames, processed_ms_format
+from flint.options import FieldOptions
 from flint.selfcal.casa import gaincal_applycal_ms
 from flint.source_finding.aegean import AegeanOutputs, run_bane_and_aegean
 from flint.utils import zip_folder
 from flint.validation import create_validation_plot
-from flint.options import FieldOptions
 
 # These are simple task wrapped functions and require no other modification
 task_preprocess_askap_ms = task(preprocess_askap_ms)

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -218,7 +218,7 @@ def task_wsclean_imager(
 
     if fits_mask:
         update_wsclean_options["fits_mask"] = fits_mask.mask_fits
-        
+
     logger.info(f"wsclean inager {ms=}")
     return wsclean_imager(
         ms=ms,
@@ -260,7 +260,10 @@ def task_get_common_beam(
 
 @task
 def task_convolve_image(
-    wsclean_cmd: WSCleanCommand, beam_shape: BeamShape, cutoff: float = 60
+    wsclean_cmd: WSCleanCommand,
+    beam_shape: BeamShape,
+    cutoff: float = 60,
+    mode: str = "image",
 ) -> Collection[Path]:
     """Convolve images to a specified resolution
 
@@ -275,7 +278,14 @@ def task_convolve_image(
     assert (
         wsclean_cmd.imageset is not None
     ), f"{wsclean_cmd.ms} has no attached imageset."
-    image_paths: Collection[Path] = wsclean_cmd.imageset.image
+
+    supported_modes = ("image", "residual")
+    assert (
+        mode in supported_modes
+    ), f"{mode=} is not supported. Known modes are {supported_modes}"
+
+    logger.info(f"EWxtracting {mode}")
+    image_paths: Collection[Path] = wsclean_cmd.imageset.__dict__.get(mode)
 
     logger.info(f"Will convolve {image_paths}")
 
@@ -454,7 +464,7 @@ def task_create_linmos_mask_wbutter_model(
         fits_rms_path=linmos_rms,
         create_signal_fits=True,
         min_snr=min_snr,
-        connectivity_shape=(2,2)
+        connectivity_shape=(2, 2),
     )
 
     logger.info(f"Created {linmos_mask_names.mask_fits}")

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -7,7 +7,7 @@ imaging flows.
 from pathlib import Path
 from typing import Any, Collection, Dict, List, Optional, TypeVar, Union
 
-from prefect import task
+from prefect import task, unmapped
 
 from flint.calibrate.aocalibrate import (
     ApplySolutions,
@@ -31,6 +31,7 @@ from flint.selfcal.casa import gaincal_applycal_ms
 from flint.source_finding.aegean import AegeanOutputs, run_bane_and_aegean
 from flint.utils import zip_folder
 from flint.validation import create_validation_plot
+from flint.options import FieldOptions
 
 # These are simple task wrapped functions and require no other modification
 task_preprocess_askap_ms = task(preprocess_askap_ms)
@@ -273,7 +274,7 @@ def task_convolve_image(
         cutoff (float, optional): Maximum major beam axis an image is allowed to have before it will not be convolved. Defaults to 60.
 
     Returns:
-        Collection[Path]: Path to the output images that have been convolved. 
+        Collection[Path]: Path to the output images that have been convolved.
     """
     assert (
         wsclean_cmd.imageset is not None
@@ -286,16 +287,18 @@ def task_convolve_image(
 
     logger.info(f"Extracting {mode}")
     image_paths: Collection[Path] = (
-        wsclean_cmd.imageset.image if mode == "image" else  wsclean_cmd.imageset.residual
+        wsclean_cmd.imageset.image if mode == "image" else wsclean_cmd.imageset.residual
     )
-    
+
     # It is possible depending on how aggressively cleaning image products are deleted that these
     # some cleaning products (e.g. residuals) do not exist. There are a number of ways one could consider
     # handling this. The pirate in me feels like less is more, so an error will be enough. Keeping
-    # things simple and avoiding the problem is probably the better way of dealing with this 
-    # situation. In time this would mean that we inspect and handle conflicting pipeline options. 
-    assert image_paths is not None, f"{image_paths=} for {mode=} and {wsclean_cmd.imageset=}"
-    
+    # things simple and avoiding the problem is probably the better way of dealing with this
+    # situation. In time this would mean that we inspect and handle conflicting pipeline options.
+    assert (
+        image_paths is not None
+    ), f"{image_paths=} for {mode=} and {wsclean_cmd.imageset=}"
+
     logger.info(f"Will convolve {image_paths}")
 
     # experience has shown that astropy units do not always work correctly
@@ -386,6 +389,38 @@ def task_linmos_images(
     )
 
     return linmos_cmd
+
+
+def _convolve_linmos_residuals(
+    wsclean_cmds: Collection[WSCleanCommand],
+    beam_shape: BeamShape,
+    field_options: FieldOptions,
+) -> LinmosCommand:
+    """An internal function that launches the convolution to a common resolution
+    and subsequent linmos of the wsclean residual images. 
+
+    Args:
+        wsclean_cmds (Collection[WSCleanCommand]): Collection of wsclean imaging results, with residual images described in the attached ``ImageSet``
+        beam_shape (BeamShape): The beam shape that residual images will be convolved to
+        field_options (FieldOptions): Options related to the processing of the field
+
+    Returns:
+        LinmosCommand: Resulting linmos command parset
+    """
+    residual_conv_images = task_convolve_image.map(
+        wsclean_cmd=wsclean_cmds,
+        beam_shape=unmapped(beam_shape),
+        cutoff=150.0,
+        mode="residual",
+    )
+    parset = task_linmos_images.submit(
+        images=residual_conv_images,
+        container=field_options.yandasoft_container,
+        suffix_str="residual.noselfcal",
+        holofile=field_options.holofile,
+    )
+
+    return parset
 
 
 @task

--- a/flint/prefect/flows/continuum_mask_pipeline.py
+++ b/flint/prefect/flows/continuum_mask_pipeline.py
@@ -22,8 +22,10 @@ from flint.calibrate.aocalibrate import find_existing_solutions
 from flint.logging import logger
 from flint.ms import MS
 from flint.naming import get_sbid_from_path
+from flint.options import FieldOptions
 from flint.prefect.clusters import get_dask_runner
 from flint.prefect.common.imaging import (
+    _convolve_linmos_residuals,
     task_convolve_image,
     task_create_apply_solutions_cmd,
     task_create_linmos_mask_model,
@@ -40,10 +42,8 @@ from flint.prefect.common.imaging import (
     task_split_by_field,
     task_wsclean_imager,
     task_zip_ms,
-    _convolve_linmos_residuals
 )
 from flint.prefect.common.utils import task_flatten
-from flint.options import FieldOptions
 
 
 def _create_linmos_mask(
@@ -179,8 +179,11 @@ def process_science_fields(
     )
 
     if field_options.linmos_residuals:
-        _convolve_linmos_residuals(wsclean_cmds=wsclean_cmds, beam_shape=beam_shape, field_options=field_options)
-        
+        _convolve_linmos_residuals(
+            wsclean_cmds=wsclean_cmds,
+            beam_shape=beam_shape,
+            field_options=field_options,
+        )
 
     aegean_outputs = task_run_bane_and_aegean.submit(
         image=parset, aegean_container=unmapped(field_options.aegean_container)
@@ -234,8 +237,8 @@ def process_science_fields(
     }
 
     for round in range(1, field_options.rounds + 1):
-        final_round = round == field_options.rounds 
-        
+        final_round = round == field_options.rounds
+
         gain_cal_options = gain_cal_rounds.get(round, None)
         wsclean_options = wsclean_rounds.get(round, None)
 
@@ -286,8 +289,11 @@ def process_science_fields(
         )
 
         if final_round and field_options.linmos_residuals:
-            _convolve_linmos_residuals(wsclean_cmds=wsclean_cmds, beam_shape=beam_shape, field_options=field_options)
-        
+            _convolve_linmos_residuals(
+                wsclean_cmds=wsclean_cmds,
+                beam_shape=beam_shape,
+                field_options=field_options,
+            )
 
         # Use the mask from the first round
         if round < field_options.rounds:

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -66,6 +66,8 @@ def process_science_fields(
         logger.info(f"Creating {str(output_split_science_path)}")
         output_split_science_path.mkdir(parents=True)
 
+    logger.info(f"{field_options=}")
+
     logger.info(f"Found the following raw measurement sets: {science_mss}")
 
     # TODO: This will likely need to be expanded should any
@@ -112,7 +114,7 @@ def process_science_fields(
         return
 
     wsclean_init = {
-        "size": 7144,
+        "size": 4144,
         "minuv_l": 235,
         "weight": "briggs -0.5",
         "auto_mask": 5,
@@ -167,7 +169,6 @@ def process_science_fields(
                 container=field_options.yandasoft_container,
                 suffix_str="residual.noselfcal",
                 holofile=field_options.holofile,
-                name="task_linmos_residual_images",
             )
 
     if field_options.rounds is None:

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -384,6 +384,12 @@ def get_parser() -> ArgumentParser:
         default=False,
         help="Co-add the per-beam cleaning residuals into a field image",
     )
+    parser.add_argument(
+        "--linmos-residuals",
+        action='store_true',
+        default=False,
+        help="Whether to linmos the cleaning residuals together. "
+    )
 
     return parser
 

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -14,8 +14,10 @@ from flint.calibrate.aocalibrate import find_existing_solutions
 from flint.logging import logger
 from flint.ms import MS
 from flint.naming import get_sbid_from_path
+from flint.options import FieldOptions
 from flint.prefect.clusters import get_dask_runner
 from flint.prefect.common.imaging import (
+    _convolve_linmos_residuals,
     task_convolve_image,
     task_create_apply_solutions_cmd,
     task_create_validation_plot,
@@ -29,10 +31,8 @@ from flint.prefect.common.imaging import (
     task_split_by_field,
     task_wsclean_imager,
     task_zip_ms,
-    _convolve_linmos_residuals
 )
 from flint.prefect.common.utils import task_flatten
-from flint.options import FieldOptions
 
 
 @flow(name="Flint Continuum Pipeline")
@@ -159,8 +159,12 @@ def process_science_fields(
                 )
 
         if field_options.linmos_residuals:
-            _convolve_linmos_residuals(wsclean_cmds=wsclean_cmds, beam_shape=beam_shape, field_options=field_options)
-            
+            _convolve_linmos_residuals(
+                wsclean_cmds=wsclean_cmds,
+                beam_shape=beam_shape,
+                field_options=field_options,
+            )
+
     if field_options.rounds is None:
         logger.info("No self-calibration will be performed. Returning")
         return
@@ -189,8 +193,8 @@ def process_science_fields(
     }
 
     for round in range(1, field_options.rounds + 1):
-        final_round = round == field_options.rounds 
-        
+        final_round = round == field_options.rounds
+
         gain_cal_options = gain_cal_rounds.get(round, None)
         wsclean_options = wsclean_rounds.get(round, None)
 
@@ -235,8 +239,12 @@ def process_science_fields(
         )
 
         if final_round and field_options.linmos_residuals:
-            _convolve_linmos_residuals(wsclean_cmds=wsclean_cmds, beam_shape=beam_shape, field_options=field_options)
-        
+            _convolve_linmos_residuals(
+                wsclean_cmds=wsclean_cmds,
+                beam_shape=beam_shape,
+                field_options=field_options,
+            )
+
         if run_aegean:
             aegean_outputs = task_run_bane_and_aegean.submit(
                 image=parset, aegean_container=unmapped(field_options.aegean_container)

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -384,12 +384,6 @@ def get_parser() -> ArgumentParser:
         default=False,
         help="Co-add the per-beam cleaning residuals into a field image",
     )
-    parser.add_argument(
-        "--linmos-residuals",
-        action='store_true',
-        default=False,
-        help="Whether to linmos the cleaning residuals together. "
-    )
 
     return parser
 

--- a/tests/test_wsclean.py
+++ b/tests/test_wsclean.py
@@ -1,0 +1,111 @@
+"""Testing some wsclean functionality. 
+"""
+import pytest
+from pathlib import Path 
+
+from flint.imager.wsclean import get_wsclean_output_names, ImageSet 
+
+
+def test_wsclean_output_named_raises():
+    with pytest.raises(FileExistsError):
+        image_set = get_wsclean_output_names(prefix="JackSparrow", subbands=4, verify_exists=True) 
+
+def test_wsclean_output_named_check_when_adding():
+    image_set = get_wsclean_output_names(
+        prefix="JackSparrow", subbands=4, verify_exists=True, check_exists_when_adding=True
+    ) 
+     
+    assert isinstance(image_set, ImageSet)
+    assert len(image_set.image) == 0
+     
+
+def test_wsclean_output_named():
+    image_set = get_wsclean_output_names(prefix="JackSparrow", subbands=4) 
+    
+    assert isinstance(image_set, ImageSet)
+    assert image_set.prefix == "JackSparrow"
+    
+    assert image_set.image is not None 
+    assert len(image_set.image) == 5
+    assert isinstance(image_set.image[0], Path) 
+
+    assert image_set.dirty is not None 
+    assert len(image_set.dirty) == 5
+    assert isinstance(image_set.dirty[0], Path) 
+
+    assert image_set.model is not None 
+    assert len(image_set.model) == 5
+    assert isinstance(image_set.model[0], Path) 
+
+    assert image_set.residual is not None 
+    assert len(image_set.residual) == 5
+    assert isinstance(image_set.residual[0], Path) 
+
+    assert image_set.psf is not None 
+    assert len(image_set.psf) == 5
+    assert isinstance(image_set.psf[0], Path) 
+
+
+
+def test_wsclean_output_named_wpols():
+    image_set = get_wsclean_output_names(prefix="JackSparrow", subbands=4, pols=("I", "Q")) 
+    
+    assert isinstance(image_set, ImageSet)
+    assert image_set.prefix == "JackSparrow"
+
+    expected = 10    
+    assert image_set.image is not None 
+    assert len(image_set.image) == expected
+    assert isinstance(image_set.image[0], Path) 
+
+    assert image_set.dirty is not None 
+    assert len(image_set.dirty) == expected
+    assert isinstance(image_set.dirty[0], Path) 
+
+    assert image_set.model is not None 
+    assert len(image_set.model) == expected
+    assert isinstance(image_set.model[0], Path) 
+
+    assert image_set.residual is not None 
+    assert len(image_set.residual) == expected
+    assert isinstance(image_set.residual[0], Path) 
+
+    assert image_set.psf is not None 
+    assert len(image_set.psf) == 5 # PSF is the same across all pols
+    assert isinstance(image_set.psf[0], Path) 
+
+
+    assert image_set.image[0] == Path("JackSparrow-0000-I-image.fits")
+    assert image_set.image[4] == Path("JackSparrow-MFS-I-image.fits")
+    assert image_set.image[5] == Path("JackSparrow-0000-Q-image.fits")
+    assert image_set.image[9] == Path("JackSparrow-MFS-Q-image.fits")
+
+
+def test_wsclean_output_named_nomfs():
+    image_set = get_wsclean_output_names(prefix="JackSparrow", subbands=4, include_mfs=False) 
+    
+    assert isinstance(image_set, ImageSet)
+    assert image_set.prefix == "JackSparrow"
+    
+    assert image_set.image is not None 
+    assert len(image_set.image) == 4
+    assert isinstance(image_set.image[0], Path) 
+
+    assert image_set.dirty is not None 
+    assert len(image_set.dirty) == 4
+    assert isinstance(image_set.dirty[0], Path) 
+
+    assert image_set.model is not None 
+    assert len(image_set.model) == 4
+    assert isinstance(image_set.model[0], Path) 
+
+    assert image_set.residual is not None 
+    assert len(image_set.residual) == 4
+    assert isinstance(image_set.residual[0], Path) 
+
+    assert image_set.psf is not None 
+    assert len(image_set.psf) == 4
+    assert isinstance(image_set.psf[0], Path) 
+
+
+

--- a/tests/test_wsclean.py
+++ b/tests/test_wsclean.py
@@ -1,79 +1,86 @@
-"""Testing some wsclean functionality. 
+"""Testing some wsclean functionality.
 """
-import pytest
-from pathlib import Path 
+from pathlib import Path
 
-from flint.imager.wsclean import get_wsclean_output_names, ImageSet 
+import pytest
+
+from flint.imager.wsclean import ImageSet, get_wsclean_output_names
 
 
 def test_wsclean_output_named_raises():
     with pytest.raises(FileExistsError):
-        _ = get_wsclean_output_names(prefix="JackSparrow", subbands=4, verify_exists=True) 
+        _ = get_wsclean_output_names(
+            prefix="JackSparrow", subbands=4, verify_exists=True
+        )
+
 
 def test_wsclean_output_named_check_when_adding():
     image_set = get_wsclean_output_names(
-        prefix="JackSparrow", subbands=4, verify_exists=True, check_exists_when_adding=True
-    ) 
-     
+        prefix="JackSparrow",
+        subbands=4,
+        verify_exists=True,
+        check_exists_when_adding=True,
+    )
+
     assert isinstance(image_set, ImageSet)
     assert len(image_set.image) == 0
-     
+
 
 def test_wsclean_output_named():
-    image_set = get_wsclean_output_names(prefix="JackSparrow", subbands=4) 
-    
+    image_set = get_wsclean_output_names(prefix="JackSparrow", subbands=4)
+
     assert isinstance(image_set, ImageSet)
     assert image_set.prefix == "JackSparrow"
-    
-    assert image_set.image is not None 
+
+    assert image_set.image is not None
     assert len(image_set.image) == 5
-    assert isinstance(image_set.image[0], Path) 
+    assert isinstance(image_set.image[0], Path)
 
-    assert image_set.dirty is not None 
+    assert image_set.dirty is not None
     assert len(image_set.dirty) == 5
-    assert isinstance(image_set.dirty[0], Path) 
+    assert isinstance(image_set.dirty[0], Path)
 
-    assert image_set.model is not None 
+    assert image_set.model is not None
     assert len(image_set.model) == 5
-    assert isinstance(image_set.model[0], Path) 
+    assert isinstance(image_set.model[0], Path)
 
-    assert image_set.residual is not None 
+    assert image_set.residual is not None
     assert len(image_set.residual) == 5
-    assert isinstance(image_set.residual[0], Path) 
+    assert isinstance(image_set.residual[0], Path)
 
-    assert image_set.psf is not None 
+    assert image_set.psf is not None
     assert len(image_set.psf) == 5
-    assert isinstance(image_set.psf[0], Path) 
-
+    assert isinstance(image_set.psf[0], Path)
 
 
 def test_wsclean_output_named_wpols():
-    image_set = get_wsclean_output_names(prefix="JackSparrow", subbands=4, pols=("I", "Q")) 
-    
+    image_set = get_wsclean_output_names(
+        prefix="JackSparrow", subbands=4, pols=("I", "Q")
+    )
+
     assert isinstance(image_set, ImageSet)
     assert image_set.prefix == "JackSparrow"
 
-    expected = 10    
-    assert image_set.image is not None 
+    expected = 10
+    assert image_set.image is not None
     assert len(image_set.image) == expected
-    assert isinstance(image_set.image[0], Path) 
+    assert isinstance(image_set.image[0], Path)
 
-    assert image_set.dirty is not None 
+    assert image_set.dirty is not None
     assert len(image_set.dirty) == expected
-    assert isinstance(image_set.dirty[0], Path) 
+    assert isinstance(image_set.dirty[0], Path)
 
-    assert image_set.model is not None 
+    assert image_set.model is not None
     assert len(image_set.model) == expected
-    assert isinstance(image_set.model[0], Path) 
+    assert isinstance(image_set.model[0], Path)
 
-    assert image_set.residual is not None 
+    assert image_set.residual is not None
     assert len(image_set.residual) == expected
-    assert isinstance(image_set.residual[0], Path) 
+    assert isinstance(image_set.residual[0], Path)
 
-    assert image_set.psf is not None 
-    assert len(image_set.psf) == 5 # PSF is the same across all pols
-    assert isinstance(image_set.psf[0], Path) 
-
+    assert image_set.psf is not None
+    assert len(image_set.psf) == 5  # PSF is the same across all pols
+    assert isinstance(image_set.psf[0], Path)
 
     assert image_set.image[0] == Path("JackSparrow-0000-I-image.fits")
     assert image_set.image[4] == Path("JackSparrow-MFS-I-image.fits")
@@ -82,30 +89,29 @@ def test_wsclean_output_named_wpols():
 
 
 def test_wsclean_output_named_nomfs():
-    image_set = get_wsclean_output_names(prefix="JackSparrow", subbands=4, include_mfs=False) 
-    
+    image_set = get_wsclean_output_names(
+        prefix="JackSparrow", subbands=4, include_mfs=False
+    )
+
     assert isinstance(image_set, ImageSet)
     assert image_set.prefix == "JackSparrow"
-    
-    assert image_set.image is not None 
+
+    assert image_set.image is not None
     assert len(image_set.image) == 4
-    assert isinstance(image_set.image[0], Path) 
+    assert isinstance(image_set.image[0], Path)
 
-    assert image_set.dirty is not None 
+    assert image_set.dirty is not None
     assert len(image_set.dirty) == 4
-    assert isinstance(image_set.dirty[0], Path) 
+    assert isinstance(image_set.dirty[0], Path)
 
-    assert image_set.model is not None 
+    assert image_set.model is not None
     assert len(image_set.model) == 4
-    assert isinstance(image_set.model[0], Path) 
+    assert isinstance(image_set.model[0], Path)
 
-    assert image_set.residual is not None 
+    assert image_set.residual is not None
     assert len(image_set.residual) == 4
-    assert isinstance(image_set.residual[0], Path) 
+    assert isinstance(image_set.residual[0], Path)
 
-    assert image_set.psf is not None 
+    assert image_set.psf is not None
     assert len(image_set.psf) == 4
-    assert isinstance(image_set.psf[0], Path) 
-
-
-
+    assert isinstance(image_set.psf[0], Path)

--- a/tests/test_wsclean.py
+++ b/tests/test_wsclean.py
@@ -8,7 +8,7 @@ from flint.imager.wsclean import get_wsclean_output_names, ImageSet
 
 def test_wsclean_output_named_raises():
     with pytest.raises(FileExistsError):
-        image_set = get_wsclean_output_names(prefix="JackSparrow", subbands=4, verify_exists=True) 
+        _ = get_wsclean_output_names(prefix="JackSparrow", subbands=4, verify_exists=True) 
 
 def test_wsclean_output_named_check_when_adding():
     image_set = get_wsclean_output_names(


### PR DESCRIPTION
A slightly larger merge than expected. The intent is to linmos together the residual clean images from wsclean. The initial attempt highlighted that the creation of an `ImageSet` was not horribly robust. It was possible for errors to be raised as some wsclean image products are deleted to conserve disk space,and when `verify_exists=True` errors would be raised. Some checks and corresponding unit tests have been added. 