### PR TITLE
Upload images as prefect markdown 

### DIFF
--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -32,6 +32,7 @@ from flint.selfcal.casa import gaincal_applycal_ms
 from flint.source_finding.aegean import AegeanOutputs, run_bane_and_aegean
 from flint.utils import zip_folder
 from flint.validation import create_validation_plot
+from flint.prefect.common.utils import upload_image_as_artifact
 
 # These are simple task wrapped functions and require no other modification
 task_preprocess_askap_ms = task(preprocess_askap_ms)
@@ -542,13 +543,16 @@ def task_extract_beam_mask_image(
 
 @task
 def task_create_validation_plot(
-    aegean_outputs: AegeanOutputs, reference_catalogue_directory: Path
+    aegean_outputs: AegeanOutputs,
+    reference_catalogue_directory: Path,
+    upload_artifact: bool = True,
 ) -> Path:
     """Create a multi-panel figure highlighting the RMS, flux scale and astrometry of a field
 
     Args:
         aegean_outputs (AegeanOutputs): Output aegean products
         reference_catalogue_directory (Path): Directory containing NVSS, SUMSS and ICRS reference catalogues. These catalogues are reconginised internally and have expected names.
+        upload_artifact (bool, optional): If True the validation plot will be uploaded to the prefect service as an artifact. Defaults to True.
 
     Returns:
         Path: Path to the output figure created
@@ -557,9 +561,14 @@ def task_create_validation_plot(
 
     logger.info(f"Will create {output_figure_path=}")
 
-    return create_validation_plot(
+    plot_path = create_validation_plot(
         rms_image_path=aegean_outputs.rms,
         source_catalogue_path=aegean_outputs.comp,
         output_path=output_figure_path,
         reference_catalogue_directory=reference_catalogue_directory,
     )
+
+    if upload_artifact:
+        upload_image_as_artifact(image_path=plot_path)
+
+    return plot_path

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -569,6 +569,9 @@ def task_create_validation_plot(
     )
 
     if upload_artifact:
-        upload_image_as_artifact(image_path=plot_path)
+        upload_image_as_artifact(
+            image_path=plot_path,
+            descrition=f"Validation plot {str(plot_path)}"
+        )
 
     return plot_path

--- a/flint/prefect/common/utils.py
+++ b/flint/prefect/common/utils.py
@@ -15,7 +15,7 @@ T = TypeVar("T")
 SUPPORTED_IMAGE_TYPES = ("png",)
 
 
-def upload_image_as_artifact(image_path: Path) -> UUID:
+def upload_image_as_artifact(image_path: Path, description: Optional[str]=None) -> UUID:
     """Create and submit a markdown artifact tracked by prefect for an
     input image. Currently supporting png formatted images.
 
@@ -25,6 +25,7 @@ def upload_image_as_artifact(image_path: Path) -> UUID:
 
     Args:
         image_path (Path): Path to the image to upload
+        description (Optional[str], optional): A description passed to the markdown artifact. Defaults to None. 
 
     Returns:
         UUID: Generated UUID of the registered artifact
@@ -43,7 +44,7 @@ def upload_image_as_artifact(image_path: Path) -> UUID:
     markdown = f"![{image_path.stem}](data:image/{image_type};base64,{image_base64})"
 
     logger.info("Registering artifact")
-    image_uuid = create_markdown_artifact(markdown=markdown)
+    image_uuid = create_markdown_artifact(markdown=markdown, description=description)
 
     return image_uuid
 

--- a/flint/prefect/common/utils.py
+++ b/flint/prefect/common/utils.py
@@ -1,7 +1,7 @@
 """Common prefect related utilities that can be used between flows.
 """
 from uuid import UUID
-from typing import Any, List, TypeVar
+from typing import Any, List, TypeVar, Optional
 from pathlib import Path
 import base64
 

--- a/flint/prefect/common/utils.py
+++ b/flint/prefect/common/utils.py
@@ -1,12 +1,51 @@
 """Common prefect related utilities that can be used between flows.
 """
+from uuid import UUID
 from typing import Any, List, TypeVar
+from pathlib import Path
+import base64
 
 from prefect import task
+from prefect.artifacts import create_markdown_artifact
 
 from flint.logging import logger
 
 T = TypeVar("T")
+
+SUPPORTED_IMAGE_TYPES = ("png",)
+
+
+def upload_image_as_artifact(image_path: Path) -> UUID:
+    """Create and submit a markdown artifact tracked by prefect for an
+    input image. Currently supporting png formatted images.
+
+    The input image is converted to a base64 encoding, and embedded directly
+    within the markdown string. Therefore, be mindful of the image size as this
+    is tracked in the postgres database.
+
+    Args:
+        image_path (Path): Path to the image to upload
+
+    Returns:
+        UUID: Generated UUID of the registered artifact
+    """
+    image_type = image_path.suffix.replace(".", "")
+    assert image_path.exists(), f"{image_path} does not exist"
+    assert (
+        image_type in SUPPORTED_IMAGE_TYPES
+    ), f"{image_path} has type {image_type}, and is not supported. Supported types are {SUPPORTED_IMAGE_TYPES}"
+
+    with open(image_path, "rb") as open_image:
+        logger.info(f"Encoding {image_path} in base64")
+        image_base64 = base64.b64encode(open_image.read()).decode()
+
+    logger.info("Creating markdown tag")
+    markdown = f"![{image_path.stem}](data:image/{image_type};base64,{image_base64})"
+
+    logger.info("Registering artifact")
+    image_uuid = create_markdown_artifact(markdown=markdown)
+
+    return image_uuid
 
 
 @task

--- a/flint/prefect/flows/continuum_mask_pipeline.py
+++ b/flint/prefect/flows/continuum_mask_pipeline.py
@@ -106,7 +106,7 @@ def process_science_fields(
     # other calibration strategies get added
     # Scan the existing bandpass directory for the existing solutions
     calibrate_cmds = find_existing_solutions(
-        bandpass_directory=bandpass_path, use_preflagged=True, use_smoothed=False
+        bandpass_directory=bandpass_path, use_preflagged=True, use_smoothed=True
     )
 
     logger.info(f"Constructed the following {calibrate_cmds=}")


### PR DESCRIPTION
This pull request introduces a feature that will upload images to the prefect server UI. 

A slightly smelly way, but speaking the with prefect devs is a supported and expected one (in fact the engineer who implemented this artifact functionality was excited by it). The subject png is encoded as a base64 string, and then a markdown data url is constructed:

```
![hello](data:unage/png;base64,base64stringhere)
```

When submitted through `prefect.artifacts.create_markdown_artifact` the markdown string is stored in the prefect database, and rendered by the UI when selected. 

Perhaps a more scalable solution would be to create a HTTP server that we can host the images on (uploaded through an authenticated http post), and then replace the data url above with the appropriate url. This requires more thought (and more external services).