### PR TITLE
Added attributed to FieldOptions

### DIFF
--- a/flint/options.py
+++ b/flint/options.py
@@ -47,3 +47,11 @@ class FieldOptions(NamedTuple):
     """Whether a Butterworth filter should be used when constructing the clean mask"""
     linmos_residuals: bool = False
     """Linmos the cleaning residuals together into a field image"""
+    beam_cutoff: float = 150
+    """Cutoff in arcseconds to use when calculating the common beam to convol to"""
+    pb_cutoff: float = 0.1
+    """Primary beam attentuation cutoff to use during linmos"""
+    use_preflagger: bool = True
+    """Whether to apply (or search for solutions with) bandpass solutions that have gone through the preflagging operations"""
+    use_smoothed: bool = True
+    """Whether to apply (or search for solutions with) a bandpass smoothing operation applied"""

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,0 +1,108 @@
+"""Very basic tests to make sure the FieldOptions class is
+somewhat tracked, especially when using an argparse object
+to create it
+"""
+from pathlib import Path
+
+from flint.options import FieldOptions
+from flint.prefect.flows.continuum_pipeline import get_parser
+
+
+def test_create_field_options():
+    parser = get_parser()
+    args = parser.parse_args(
+        """/scratch3/gal16b/askap_sbids/112334/ 
+        /scratch3/gal16b/askap_sbids/111/ 
+        --holofile /scratch3/projects/spiceracs/RACS_Low2_Holography/akpb.iquv.square_6x6.63.887MHz.SB39549.cube.fits 
+        --calibrate-container /scratch3/gal16b/containers/calibrate.sif 
+        --flagger-container /scratch3/gal16b/containers/aoflagger.sif  
+        --wsclean-container /scratch3/projects/spiceracs/singularity_images/wsclean_force_mask.sif  
+        --yandasoft-container /scratch3/gal16b/containers/yandasoft.sif 
+        --cluster-config /scratch3/gal16b/split/petrichor.yaml 
+        --selfcal-rounds 2 
+        --split-path $(pwd) 
+        --zip-ms 
+        --run-aegean 
+        --aegean-container '/scratch3/gal16b/containers/aegean.sif' 
+        --reference-catalogue-directory '/scratch3/gal16b/reference_catalogues/' 
+        --linmos-residuals
+    """.split()
+    )
+
+    field_options = FieldOptions(
+        flagger_container=args.flagger_container,
+        calibrate_container=args.calibrate_container,
+        holofile=args.holofile,
+        expected_ms=args.expected_ms,
+        wsclean_container=args.wsclean_container,
+        yandasoft_container=args.yandasoft_container,
+        rounds=args.selfcal_rounds,
+        zip_ms=args.zip_ms,
+        run_aegean=args.run_aegean,
+        aegean_container=args.aegean_container,
+        no_imaging=args.no_imaging,
+        reference_catalogue_directory=args.reference_catalogue_directory,
+        linmos_residuals=args.linmos_residuals,
+        beam_cutoff=args.beam_cutoff,
+        pb_cutoff=args.pb_cutoff,
+        use_preflagger=args.use_preflagger,
+        use_smoothed=args.use_smoothed,
+    )
+
+    assert isinstance(field_options, FieldOptions)
+    assert field_options.use_preflagger is False
+    assert field_options.use_smoothed is False
+    assert field_options.zip_ms is True
+    assert field_options.linmos_residuals is True
+    assert field_options.rounds == 2
+    assert isinstance(field_options.wsclean_container, Path)
+
+
+def test_create_field_options2():
+    parser = get_parser()
+    args = parser.parse_args(
+        """/scratch3/gal16b/askap_sbids/112334/ 
+        /scratch3/gal16b/askap_sbids/111/ 
+        --holofile /scratch3/projects/spiceracs/RACS_Low2_Holography/akpb.iquv.square_6x6.63.887MHz.SB39549.cube.fits 
+        --calibrate-container /scratch3/gal16b/containers/calibrate.sif 
+        --flagger-container /scratch3/gal16b/containers/aoflagger.sif  
+        --wsclean-container /scratch3/projects/spiceracs/singularity_images/wsclean_force_mask.sif  
+        --yandasoft-container /scratch3/gal16b/containers/yandasoft.sif 
+        --cluster-config /scratch3/gal16b/split/petrichor.yaml 
+        --selfcal-rounds 2 
+        --split-path $(pwd) 
+        --run-aegean 
+        --aegean-container '/scratch3/gal16b/containers/aegean.sif' 
+        --reference-catalogue-directory '/scratch3/gal16b/reference_catalogues/' 
+        --use-preflagger
+        --use-smoothed
+    """.split()
+    )
+
+    field_options = FieldOptions(
+        flagger_container=args.flagger_container,
+        calibrate_container=args.calibrate_container,
+        holofile=args.holofile,
+        expected_ms=args.expected_ms,
+        wsclean_container=args.wsclean_container,
+        yandasoft_container=args.yandasoft_container,
+        rounds=args.selfcal_rounds,
+        zip_ms=args.zip_ms,
+        run_aegean=args.run_aegean,
+        aegean_container=args.aegean_container,
+        no_imaging=args.no_imaging,
+        reference_catalogue_directory=args.reference_catalogue_directory,
+        linmos_residuals=args.linmos_residuals,
+        beam_cutoff=args.beam_cutoff,
+        pb_cutoff=args.pb_cutoff,
+        use_preflagger=args.use_preflagger,
+        use_smoothed=args.use_smoothed,
+    )
+
+    assert isinstance(field_options, FieldOptions)
+    assert field_options.use_preflagger is True
+    assert field_options.use_smoothed is True
+    assert field_options.zip_ms is False
+    assert field_options.linmos_residuals is False
+    assert field_options.rounds == 2
+    assert isinstance(field_options.wsclean_container, Path)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -11,20 +11,20 @@ from flint.prefect.flows.continuum_pipeline import get_parser
 def test_create_field_options():
     parser = get_parser()
     args = parser.parse_args(
-        """/scratch3/gal16b/askap_sbids/112334/ 
-        /scratch3/gal16b/askap_sbids/111/ 
-        --holofile /scratch3/projects/spiceracs/RACS_Low2_Holography/akpb.iquv.square_6x6.63.887MHz.SB39549.cube.fits 
-        --calibrate-container /scratch3/gal16b/containers/calibrate.sif 
-        --flagger-container /scratch3/gal16b/containers/aoflagger.sif  
-        --wsclean-container /scratch3/projects/spiceracs/singularity_images/wsclean_force_mask.sif  
-        --yandasoft-container /scratch3/gal16b/containers/yandasoft.sif 
-        --cluster-config /scratch3/gal16b/split/petrichor.yaml 
-        --selfcal-rounds 2 
-        --split-path $(pwd) 
-        --zip-ms 
-        --run-aegean 
-        --aegean-container '/scratch3/gal16b/containers/aegean.sif' 
-        --reference-catalogue-directory '/scratch3/gal16b/reference_catalogues/' 
+        """/scratch3/gal16b/askap_sbids/112334/
+        /scratch3/gal16b/askap_sbids/111/
+        --holofile /scratch3/projects/spiceracs/RACS_Low2_Holography/akpb.iquv.square_6x6.63.887MHz.SB39549.cube.fits
+        --calibrate-container /scratch3/gal16b/containers/calibrate.sif
+        --flagger-container /scratch3/gal16b/containers/aoflagger.sif
+        --wsclean-container /scratch3/projects/spiceracs/singularity_images/wsclean_force_mask.sif
+        --yandasoft-container /scratch3/gal16b/containers/yandasoft.sif
+        --cluster-config /scratch3/gal16b/split/petrichor.yaml
+        --selfcal-rounds 2
+        --split-path $(pwd)
+        --zip-ms
+        --run-aegean
+        --aegean-container '/scratch3/gal16b/containers/aegean.sif'
+        --reference-catalogue-directory '/scratch3/gal16b/reference_catalogues/'
         --linmos-residuals
     """.split()
     )
@@ -61,19 +61,19 @@ def test_create_field_options():
 def test_create_field_options2():
     parser = get_parser()
     args = parser.parse_args(
-        """/scratch3/gal16b/askap_sbids/112334/ 
-        /scratch3/gal16b/askap_sbids/111/ 
-        --holofile /scratch3/projects/spiceracs/RACS_Low2_Holography/akpb.iquv.square_6x6.63.887MHz.SB39549.cube.fits 
-        --calibrate-container /scratch3/gal16b/containers/calibrate.sif 
-        --flagger-container /scratch3/gal16b/containers/aoflagger.sif  
-        --wsclean-container /scratch3/projects/spiceracs/singularity_images/wsclean_force_mask.sif  
-        --yandasoft-container /scratch3/gal16b/containers/yandasoft.sif 
-        --cluster-config /scratch3/gal16b/split/petrichor.yaml 
-        --selfcal-rounds 2 
-        --split-path $(pwd) 
-        --run-aegean 
-        --aegean-container '/scratch3/gal16b/containers/aegean.sif' 
-        --reference-catalogue-directory '/scratch3/gal16b/reference_catalogues/' 
+        """/scratch3/gal16b/askap_sbids/112334/
+        /scratch3/gal16b/askap_sbids/111/
+        --holofile /scratch3/projects/spiceracs/RACS_Low2_Holography/akpb.iquv.square_6x6.63.887MHz.SB39549.cube.fits
+        --calibrate-container /scratch3/gal16b/containers/calibrate.sif
+        --flagger-container /scratch3/gal16b/containers/aoflagger.sif
+        --wsclean-container /scratch3/projects/spiceracs/singularity_images/wsclean_force_mask.sif
+        --yandasoft-container /scratch3/gal16b/containers/yandasoft.sif
+        --cluster-config /scratch3/gal16b/split/petrichor.yaml
+        --selfcal-rounds 2
+        --split-path $(pwd)
+        --run-aegean
+        --aegean-container '/scratch3/gal16b/containers/aegean.sif'
+        --reference-catalogue-directory '/scratch3/gal16b/reference_catalogues/'
         --use-preflagger
         --use-smoothed
     """.split()


### PR DESCRIPTION
Added some additional options to the `FieldOptions` class, see #42 . Some very basic tests were added for sanity to make sure that the argparse in an example flow is compatible with the FieldOptions. 

Options were added to the `flint_flow_continuum_pipeline` script. 