### PR TITLE
Remove aoflagging between self-calibration rounds

### DIFF
--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -50,7 +50,7 @@ class WSCleanOptions(NamedTuple):
     """How deep the construct clean mask is during each cycle"""
     auto_threshold: float = 0.5
     """How deep to clean once initial clean threshold reached"""
-    threshold: Optional[float] = 0.0
+    threshold: Optional[float] = None
     """Threshold in Jy to stop cleaning"""
     channels_out: int = 4
     """Number of output channels"""

--- a/flint/naming.py
+++ b/flint/naming.py
@@ -46,7 +46,7 @@ def raw_ms_format(in_name: str) -> Union[None, RawNameComponents]:
     results = regex.match(in_name)
 
     if results is None:
-        logger.info(f"No results to {in_name} found")
+        logger.debug(f"No raw_ms_format results to {in_name} found")
         return None
 
     groups = results.groupdict()
@@ -95,7 +95,7 @@ def processed_ms_format(in_name: Union[str, Path]) -> ProcessedNameComponents:
     results = regex.match(in_name)
 
     if results is None:
-        logger.info(f"No results to {in_name} found")
+        logger.debug(f"No processed_ms_format results to {in_name} found")
         return None
 
     groups = results.groupdict()

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -272,12 +272,12 @@ def process_science_fields(
 
             if run_validation:
                 validation_plot = task_create_validation_plot.submit(
-                    processed_mss=flag_mss,
+                    processed_mss=cal_mss,
                     aegean_outputs=aegean_outputs,
                     reference_catalogue_directory=field_options.reference_catalogue_directory,
                 )
                 validation_tables = task_create_validation_tables.submit(
-                    processed_mss=flag_mss,
+                    processed_mss=cal_mss,
                     aegean_outputs=aegean_outputs,
                     reference_catalogue_directory=field_options.reference_catalogue_directory,
                 )

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -119,8 +119,8 @@ def process_science_fields(
 
     wsclean_init = {
         "size": 7144,
-        "minuv_l": 235,
-        "weight": "briggs -0.5",
+        "minuv_m": 235,
+        "weight": "briggs -1.0",
         "auto_mask": 5,
         "multiscale": True,
         "local_rms_window": 55,
@@ -186,22 +186,24 @@ def process_science_fields(
         return
 
     gain_cal_rounds = {
-        1: {"solint": "1200s", "uvrange": ">235lambda", "nspw": 1},
-        2: {"solint": "60s", "uvrange": ">235lambda", "nspw": 1},
+        1: {"solint": "1200s", "uvrange": ">235m", "nspw": 1},
+        2: {"solint": "60s", "uvrange": ">235m", "nspw": 1},
     }
     wsclean_rounds = {
         1: {
             "size": 7144,
+            "weight": "briggs -1.0",
             "multiscale": True,
-            "minuv_l": 235,
+            "minuv_m": 235,
             "auto_mask": 4,
             "local_rms_window": 55,
             "multiscale_scales": (0, 15, 30, 40, 50, 60, 70, 120, 240, 480),
         },
         2: {
             "size": 7144,
+            "weight": "briggs -1.0",
             "multiscale": True,
-            "minuv_l": 235,
+            "minuv_m": 235,
             "auto_mask": 4.0,
             "local_rms_window": 55,
             "multiscale_scales": (0, 15, 30, 40, 50, 60, 70, 120, 240, 480),
@@ -221,12 +223,8 @@ def process_science_fields(
             archive_input_ms=field_options.zip_ms,
             wait_for=[validation_plot, validation_tables],
         )
-
-        flag_mss = task_flag_ms_aoflagger.map(
-            ms=cal_mss, container=field_options.flagger_container, rounds=1
-        )
         wsclean_cmds = task_wsclean_imager.map(
-            in_ms=flag_mss,
+            in_ms=cal_mss,
             wsclean_container=field_options.wsclean_container,
             update_wsclean_options=unmapped(wsclean_options),
         )

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -119,7 +119,7 @@ def process_science_fields(
 
     wsclean_init = {
         "size": 7144,
-        "minuv_m": 235,
+        "minuvw_m": 235,
         "weight": "briggs -1.0",
         "auto_mask": 5,
         "multiscale": True,
@@ -194,7 +194,7 @@ def process_science_fields(
             "size": 7144,
             "weight": "briggs -1.0",
             "multiscale": True,
-            "minuv_m": 235,
+            "minuvw_m": 235,
             "auto_mask": 4,
             "local_rms_window": 55,
             "multiscale_scales": (0, 15, 30, 40, 50, 60, 70, 120, 240, 480),
@@ -203,7 +203,7 @@ def process_science_fields(
             "size": 7144,
             "weight": "briggs -1.0",
             "multiscale": True,
-            "minuv_m": 235,
+            "minuvw_m": 235,
             "auto_mask": 4.0,
             "local_rms_window": 55,
             "multiscale_scales": (0, 15, 30, 40, 50, 60, 70, 120, 240, 480),


### PR DESCRIPTION
Initially the continuum pipelines would run aoflagger after:
- initial bandpass application
- after apply solutions from each round of self-calibration

It seems as though the second items is not necessarily needed, and could in fact cause issues. Perhaps related to the `ASKAP.lua` strategy I have tried to write. Perhaps I have messed up the actual strategy and am unflagging (somehow) bad data. 
 