### PR TITLE
Fixed the bandpass smoother

### DIFF
--- a/flint/bptools/smoother.py
+++ b/flint/bptools/smoother.py
@@ -19,7 +19,7 @@ def divide_bandpass_by_ref_ant_preserve_phase(complex_gains: np.ndarray, ref_ant
     # Unpack the valuse for short hand use
     g_x = complex_gains[:,:,0]
     d_xy = complex_gains[:,:,1]
-    d_yx = complex_gains[:,:,2]
+    d_yx = -complex_gains[:,:,2]
     g_y = complex_gains[:,:,3]
 
     # In the operations below our ship only wants to be touching 
@@ -32,15 +32,18 @@ def divide_bandpass_by_ref_ant_preserve_phase(complex_gains: np.ndarray, ref_ant
     ref_g_y = ref_g_y / np.abs(ref_g_y)
 
     # Now here is the math, from one Captain Daniel Mitchell
-    # g_x and g_y.d_yx by g_x(ref) and g_y and g_x.d_xy by g_y(ref). i.e. assuming that xy-phase = 0 (due to the ODC) and that the cross terms are leakage
+    # g_x and g_y.d_yx by g_x(ref) and g_y and g_x.d_xy by g_y(ref). 
+    # i.e. assuming that xy-phase = 0 (due to the ODC) and that the cross terms are leakage
     g_x_prime = g_x / ref_g_x
-    d_xy_prime = (g_y * d_xy) / ref_g_x
-    d_yx_prime = (g_x * d_yx) / ref_g_y
+    d_xy_prime = d_xy / ref_g_y
+    d_yx_prime = d_yx / ref_g_x
     g_y_prime = g_y / ref_g_y
 
     # Construct the output array to slice things into
     bp_p = np.zeros_like(complex_gains) * np.nan
 
+    logger.info("Slicing in referenced results")
+    logger.info(f"{g_x_prime.shape=} {d_xy_prime.shape=} {d_yx_prime.shape=} {g_y_prime.shape=}")
     # Place things into place
     bp_p[:, :, 0] = g_x_prime
     bp_p[:, :, 1] = d_xy_prime

--- a/flint/bptools/smoother.py
+++ b/flint/bptools/smoother.py
@@ -149,6 +149,7 @@ def smooth_bandpass_complex_gains(
         "Consider whether you really want to be smoothing when using continuum data. "
     )
     for ant in range(ants):
+        # TODO: This will be smoothing the X_y and Y_x. Should this actually be done?
         for pol in range(pols):
             smoothed_complex_gains[ant, :, pol].real = smooth_data(
                 data=complex_gains[ant, :, pol].real,

--- a/flint/bptools/smoother.py
+++ b/flint/bptools/smoother.py
@@ -49,7 +49,7 @@ def smooth_data(
     data: np.ndarray,
     window_size: int,
     polynomial_order: int,
-    apply_median_filter: bool = True,
+    apply_median_filter: bool = False,
 ) -> np.ndarray:
     """Smooth a 1-dimensional dataset. Internally it uses a savgol filter as
     implemented in scipy.signal.savgol_filter. It is intended to be used to
@@ -68,7 +68,7 @@ def smooth_data(
         data (np.ndarray): The 1-dimensional data to be smoothed.
         window_size (int): The size of the window function of the savgol filter. Passed directly to savgol.
         polynomial_order (int): The order of the polynomial of the savgol filter. Passed directly to savgol.
-        apply_median_filter (bool, optional): Apply a median filter to the data before applying the savgol filter using the same window size. Defaults to True.
+        apply_median_filter (bool, optional): Apply a median filter to the data before applying the savgol filter using the same window size. Defaults to False.
 
     Returns:
         np.ndarray: Smoothed dataset

--- a/flint/bptools/smoother.py
+++ b/flint/bptools/smoother.py
@@ -7,6 +7,48 @@ from scipy.signal import savgol_filter
 from flint.logging import logger
 
 
+def divide_bandpass_by_ref_ant_preserve_phase(complex_gains: np.ndarray, ref_ant: int) -> np.ndarray:
+
+    assert (
+        len(complex_gains.shape) == 3
+    ), f"The shape of the input complex gains should be of rank 3 in form (ant, chan, pol). Received {complex_gains.shape}"
+
+    logger.info(f"Dividing bandpass gain solutions using reference antenna={ref_ant}, using correct phasor")
+
+
+    # Unpack the valuse for short hand use
+    g_x = complex_gains[:,:,0]
+    d_xy = complex_gains[:,:,1]
+    d_yx = complex_gains[:,:,2]
+    g_y = complex_gains[:,:,3]
+
+    # In the operations below our ship only wants to be touching 
+    # the phases in a piratey manner. The amplitudes should remina
+    # unchanged. Construct phasors of the nominated reference antenna
+    ref_g_x = complex_gains[ref_ant, :, 0]
+    ref_g_x = ref_g_x / np.abs(ref_g_x)
+
+    ref_g_y = complex_gains[ref_ant, :, 3]
+    ref_g_y = ref_g_y / np.abs(ref_g_y)
+
+    # Now here is the math, from one Captain Daniel Mitchell
+    # g_x and g_y.d_yx by g_x(ref) and g_y and g_x.d_xy by g_y(ref). i.e. assuming that xy-phase = 0 (due to the ODC) and that the cross terms are leakage
+    g_x_prime = g_x / ref_g_x
+    d_xy_prime = (g_y * d_xy) / ref_g_x
+    d_yx_prime = (g_x * d_yx) / ref_g_y
+    g_y_prime = g_y / ref_g_y
+
+    # Construct the output array to slice things into
+    bp_p = np.zeros_like(complex_gains) * np.nan
+
+    # Place things into place
+    bp_p[:, :, 0] = g_x_prime
+    bp_p[:, :, 1] = d_xy_prime
+    bp_p[:, :, 2] = d_yx_prime
+    bp_p[:, :, 3] = g_y_prime
+
+    return bp_p
+
 def divide_bandpass_by_ref_ant(complex_gains: np.ndarray, ref_ant: int) -> np.ndarray:
     """Divide the bandpass compelx gains (solved for initially by something like
     calibrate) by a nominated reference antenna. In the case of ``calibrate``
@@ -16,7 +58,9 @@ def divide_bandpass_by_ref_ant(complex_gains: np.ndarray, ref_ant: int) -> np.nd
     >> (ant, channel, pol)
 
     Internally this function will construct a phasor:
-    >> phasor = G_{ref_ant} / abs(G_{ref_ant})
+    >> phasor = Jones_{ref_ant} / abs(Jones_{ref_ant})
+    >> shift = Jones_{ref_ant}[0] / and(Jones_{ref_ant}[0])
+    >> phasor_shifted = phasor / shift
 
     which is applied to all antennas in ``complex_gains``.
 
@@ -31,7 +75,7 @@ def divide_bandpass_by_ref_ant(complex_gains: np.ndarray, ref_ant: int) -> np.nd
         len(complex_gains.shape) == 3
     ), f"The shape of the input complex gains should be of rank 3 in form (ant, chan, pol). Received {complex_gains.shape}"
 
-    logger.info(f"Dividing bandpass gain solutions using reference antenna={ref_ant}")
+    logger.info(f"Dividing bandpass gain solutions using reference antenna={ref_ant} with shifted phasor")
 
     # Make a copy of the data to avoid editing it whereever else it might be.
     # Trust nothing you pirate.
@@ -42,9 +86,12 @@ def divide_bandpass_by_ref_ant(complex_gains: np.ndarray, ref_ant: int) -> np.nd
     ref_ant_phasor = ref_ant_solutions / np.abs(ref_ant_solutions)
     ref_ant_shift = (ref_ant_solutions[:, 0] / np.abs(ref_ant_solutions[:, 0]))[:, None]
 
+    # This preserves the consistency of the phase within an single Jones. Essentially
+    # setting the reference to the Xx term of the reference antenna. 
     phasor_shift = ref_ant_phasor / ref_ant_shift
 
-    complex_gains = complex_gains / ref_ant_phasor / phasor_shift[None, :, :]
+    logger.info("Multipply, no divide")
+    complex_gains = complex_gains / ref_ant_phasor[None, :, :] * phasor_shift[None, :, :]
 
     return complex_gains
 
@@ -145,17 +192,13 @@ def smooth_bandpass_complex_gains(
         len(complex_gains.shape) == 3
     ), f"The shape of the input complex gains should be of rank 3 in form (ant, chan, pol). Received {complex_gains.shape}"
 
-    smoothed_complex_gains = np.zeros_like(complex_gains) * np.nan
+    # Duplicate the original, ya filthy pirate
+    smoothed_complex_gains = complex_gains.copy()
 
     ants, chans, pols = complex_gains.shape
 
     logger.info(f"Smoothing using {window_size=} {polynomial_order=}")
-    logger.critical(
-        "BE CAREFUL - there are no constraints to prevent smoothing over spectral window boundaries. "
-    )
-    logger.critical(
-        "Consider whether you really want to be smoothing when using continuum data. "
-    )
+
     for ant in range(ants):
         # TODO: This will be smoothing the X_y and Y_x. Should this actually be done?
         for pol in smooth_jones_elements:

--- a/flint/bptools/smoother.py
+++ b/flint/bptools/smoother.py
@@ -38,9 +38,13 @@ def divide_bandpass_by_ref_ant(complex_gains: np.ndarray, ref_ant: int) -> np.nd
     complex_gains = complex_gains.copy()
 
     ref_ant_solutions = complex_gains[ref_ant]
-    ref_ant_phasor = ref_ant_solutions / np.abs(ref_ant_solutions)
 
-    complex_gains = complex_gains / ref_ant_phasor[None, :, :]
+    ref_ant_phasor = ref_ant_solutions / np.abs(ref_ant_solutions)
+    ref_ant_shift = (ref_ant_solutions[:, 0] / np.abs(ref_ant_solutions[:, 0]))[:, None]
+
+    phasor_shift = ref_ant_phasor / ref_ant_shift
+
+    complex_gains = complex_gains / ref_ant_phasor / phasor_shift[None, :, :]
 
     return complex_gains
 

--- a/flint/bptools/smoother.py
+++ b/flint/bptools/smoother.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 import numpy as np
 from scipy.ndimage import median_filter
 from scipy.signal import savgol_filter
@@ -108,6 +110,7 @@ def smooth_bandpass_complex_gains(
     window_size: int = 16,
     polynomial_order: int = 4,
     apply_median_filter: bool = True,
+    smooth_jones_elements: Tuple[int, ...] = (0, 1, 2, 3),
 ) -> np.ndarray:
     """Smooth bandpass solutions by applying a savgol filter to the real and imaginary components
     of each of the antenna based polarisation solutions across channels.
@@ -128,6 +131,7 @@ def smooth_bandpass_complex_gains(
         window_size (int, optional): The size of the window function of the savgol filter. Passed directly to savgol. Defaults to 16.
         polynomial_order (int, optional): The order of the polynomial of the savgol filter. Passed directly to savgol. Defaults to 4.
         apply_median_filter (bool, optional): Apply a median filter to the data before applying the savgol filter using the same window size. Defaults to True.
+        smoothe_jones_elements (Tuple[int, ...], optional): Which elements of the antennae Jones will be smoothed through frequency, i.e. X_x, X_y, Y_x, Y_y. Defaults to (0, 1, 2, 3).
 
     Returns:
         np.ndarray: Smoothed complex gains
@@ -150,7 +154,9 @@ def smooth_bandpass_complex_gains(
     )
     for ant in range(ants):
         # TODO: This will be smoothing the X_y and Y_x. Should this actually be done?
-        for pol in range(pols):
+        for pol in smooth_jones_elements:
+            assert pol in (0, 1, 2, 3), f"{pol=} is not valid Jones entry. "
+
             smoothed_complex_gains[ant, :, pol].real = smooth_data(
                 data=complex_gains[ant, :, pol].real,
                 window_size=window_size,

--- a/flint/bptools/smoother.py
+++ b/flint/bptools/smoother.py
@@ -19,7 +19,7 @@ def divide_bandpass_by_ref_ant_preserve_phase(complex_gains: np.ndarray, ref_ant
     # Unpack the valuse for short hand use
     g_x = complex_gains[:,:,0]
     d_xy = complex_gains[:,:,1]
-    d_yx = -complex_gains[:,:,2]
+    d_yx = complex_gains[:,:,2]
     g_y = complex_gains[:,:,3]
 
     # In the operations below our ship only wants to be touching 

--- a/flint/calibrate/aocalibrate.py
+++ b/flint/calibrate/aocalibrate.py
@@ -28,7 +28,6 @@ from flint.bptools.preflagger import (
     flags_over_threshold,
 )
 from flint.bptools.smoother import (
-    divide_bandpass_by_ref_ant,
     divide_bandpass_by_ref_ant_preserve_phase,
     smooth_bandpass_complex_gains,
 )

--- a/flint/calibrate/aocalibrate.py
+++ b/flint/calibrate/aocalibrate.py
@@ -203,6 +203,7 @@ def plot_solutions(
         logger.info(f"Overwriting reference antenna selection, using {ref_ant=}")
 
     if ref_ant is not None:
+        # TODO: This is going to change the amplitudes as well. This is likely not wanted!
         data = data / ao_sols.bandpass[plot_sol, ref_ant, :, :]
 
     amplitudes = np.abs(data)

--- a/flint/calibrate/aocalibrate.py
+++ b/flint/calibrate/aocalibrate.py
@@ -845,6 +845,8 @@ def flag_aosolutions(
     out_solutions_path: Optional[Path] = None,
     smooth_solutions: bool = False,
     plot_solutions_throughout: bool = True,
+    smooth_window_size: int = 16,
+    smooth_polynomial_order: int = 4,
 ) -> FlaggedAOSolution:
     """Will open a previously solved ao-calibrate solutions file and flag additional channels and antennae.
 
@@ -854,6 +856,8 @@ def flag_aosolutions(
 
     The second stage will flag an entire antenna if more then 80 percent of the flags for a polarisation are flagged.
 
+    Keywords that with the `smooth` prefix are passed to the `smooth_bandpass_complex_gains` function.
+
     Args:
         solutions_path (Path): Location of the solutions file to examine and flag.
         ref_ant (int, optional): Reference antenna to use, which is important when searching for phase-outliers and to smooth the bandpass. If ref_ant < 0, then an optimal one is selected. Defaults to -1.
@@ -862,6 +866,8 @@ def flag_aosolutions(
         out_solutions_path (Optional[Path], optional): The output path of the flagged solutions file. If None, the solutions_path provided is used. Defaults to None.
         smooth_solutions (blool, optional): Smooth the complex gain solutions after flaggined. Defaults to False.
         plot_solutions_throughout (bool, Optional): If True, the solutions will be plotted at different stages of processing. Defaults to True.
+        smooth_window_size (int, optional): The size of the window function of the savgol filter. Passed directly to savgol. Defaults to 16.
+        smooth_polynomial_order (int, optional): The order of the polynomial of the savgol filter. Passed directly to savgol. Defaults to 4.
 
     Returns:
         FlaggedAOSolution: Path to the updated solutions file, intermediate solution files and plots along the way
@@ -991,7 +997,11 @@ def flag_aosolutions(
             # )
             logger.critical("Smoothing. and not dividing by a reference antenna. ")
             complex_gains = bandpass[time]
-            bandpass[time] = smooth_bandpass_complex_gains(complex_gains=complex_gains)
+            bandpass[time] = smooth_bandpass_complex_gains(
+                complex_gains=complex_gains,
+                window_size=smooth_window_size,
+                polynomial_order=smooth_polynomial_order,
+            )
 
         out_solutions_path = get_aocalibrate_output_path(
             ms_path=solutions_path, include_preflagger=True, include_smoother=True

--- a/flint/calibrate/aocalibrate.py
+++ b/flint/calibrate/aocalibrate.py
@@ -29,6 +29,7 @@ from flint.bptools.preflagger import (
 )
 from flint.bptools.smoother import (
     divide_bandpass_by_ref_ant,
+    divide_bandpass_by_ref_ant_preserve_phase,
     smooth_bandpass_complex_gains,
 )
 from flint.exceptions import PhaseOutlierFitError
@@ -992,11 +993,9 @@ def flag_aosolutions(
     if smooth_solutions:
         logger.info("Smoothing the bandpass solutions. ")
         for time in range(solutions.nsol):
-            # complex_gains = divide_bandpass_by_ref_ant(
-            #     complex_gains=bandpass[time], ref_ant=ref_ant
-            # )
-            logger.critical("Smoothing. and not dividing by a reference antenna. ")
-            complex_gains = bandpass[time]
+            complex_gains = divide_bandpass_by_ref_ant_preserve_phase(
+                complex_gains=bandpass[time], ref_ant=ref_ant
+            )     
             bandpass[time] = smooth_bandpass_complex_gains(
                 complex_gains=complex_gains,
                 window_size=smooth_window_size,

--- a/flint/calibrate/aocalibrate.py
+++ b/flint/calibrate/aocalibrate.py
@@ -986,12 +986,12 @@ def flag_aosolutions(
     if smooth_solutions:
         logger.info("Smoothing the bandpass solutions. ")
         for time in range(solutions.nsol):
-            complex_gains = divide_bandpass_by_ref_ant(
-                complex_gains=bandpass[time], ref_ant=ref_ant
-            )
-            logger.critical("Not smoothing. Just reference antenna division. ")
-            bandpass[time] = complex_gains
-            # bandpass[time] = smooth_bandpass_complex_gains(complex_gains=complex_gains)
+            # complex_gains = divide_bandpass_by_ref_ant(
+            #     complex_gains=bandpass[time], ref_ant=ref_ant
+            # )
+            logger.critical("Smoothing. and not dividing by a reference antenna. ")
+            complex_gains = bandpass[time]
+            bandpass[time] = smooth_bandpass_complex_gains(complex_gains=complex_gains)
 
         out_solutions_path = get_aocalibrate_output_path(
             ms_path=solutions_path, include_preflagger=True, include_smoother=True

--- a/flint/calibrate/aocalibrate.py
+++ b/flint/calibrate/aocalibrate.py
@@ -1,5 +1,6 @@
 """Code to use AO calibrate s
 """
+
 from __future__ import annotations  # used to keep mypy/pylance happy in AOSolutions
 
 import struct
@@ -832,6 +833,8 @@ class FlaggedAOSolution(NamedTuple):
     """Path to the final set of flagged solutions"""
     plots: Collection[Path]
     """Contains paths to the plots generated throughout the flagging and smoothing procedure"""
+    bandpass: np.ndarray
+    """The bandpass solutions after flagging, as saved in the solutions file"""
 
 
 def flag_aosolutions(
@@ -986,7 +989,9 @@ def flag_aosolutions(
             complex_gains = divide_bandpass_by_ref_ant(
                 complex_gains=bandpass[time], ref_ant=ref_ant
             )
-            bandpass[time] = smooth_bandpass_complex_gains(complex_gains=complex_gains)
+            logger.critical("Not smoothing. Just reference antenna division. ")
+            bandpass[time] = complex_gains
+            # bandpass[time] = smooth_bandpass_complex_gains(complex_gains=complex_gains)
 
         out_solutions_path = get_aocalibrate_output_path(
             ms_path=solutions_path, include_preflagger=True, include_smoother=True
@@ -1006,7 +1011,9 @@ def flag_aosolutions(
         logger.critical(msg)
         raise ValueError(msg)
 
-    flagged_aosolutions = FlaggedAOSolution(path=out_solutions_path, plots=tuple(plots))
+    flagged_aosolutions = FlaggedAOSolution(
+        path=out_solutions_path, plots=tuple(plots), bandpass=bandpass
+    )
 
     return flagged_aosolutions
 

--- a/flint/prefect/flows/bandpass_pipeline.py
+++ b/flint/prefect/flows/bandpass_pipeline.py
@@ -69,11 +69,17 @@ def task_bandpass_create_apply_solutions_cmd(
 
 
 @task
-def task_flag_solutions(calibrate_cmd: CalibrateCommand) -> CalibrateCommand:
+def task_flag_solutions(
+    calibrate_cmd: CalibrateCommand,
+    smooth_window_size: int = 16,
+    smooth_polynomial_order: int = 4,
+) -> CalibrateCommand:
     """Flag calibration solutions
 
     Args:
         calibrate_cmd (CalibrateCommand): Calibrate command that contains path to the solution file that will be flagged
+        smooth_window_size (int, optional): The size of the window function of the savgol filter. Passed directly to savgol. Defaults to 16.
+        smooth_polynomial_order (int, optional): The order of the polynomial of the savgol filter. Passed directly to savgol. Defaults to 4.
 
     Returns:
         CalibrateCommand: Calibrate command with update meta-data describing the new solutions file
@@ -97,6 +103,8 @@ def task_flag_solutions(calibrate_cmd: CalibrateCommand) -> CalibrateCommand:
         flag_cut=3,
         plot_dir=plot_dir,
         smooth_solutions=True,
+        smooth_window_size=smooth_window_size,
+        smooth_polynomial_order=smooth_polynomial_order,
     )
 
     for image_path in flagged_solutions.plots:
@@ -130,7 +138,7 @@ def run_bandpass_stage(
         source_name_prefix (str, optional): Name of the field being calibrated. Defaults to "B1934-638".
         skip_rotation (bool, optional): If ``True`` the rotation of the ASKAP visibility from the antenna frame to the sky-frame will be skipped. Defaults to False.
         smooth_window_size (int, optional): The size of the window function of the savgol filter. Passed directly to savgol. Defaults to 16.
-        wmooth_polynomial_order (int, optional): The order of the polynomial of the savgol filter. Passed directly to savgol. Defaults to 4.
+        smooth_polynomial_order (int, optional): The order of the polynomial of the savgol filter. Passed directly to savgol. Defaults to 4.
 
     Returns:
         List[CalibrateCommand]: Set of calibration commands used

--- a/flint/prefect/flows/bandpass_pipeline.py
+++ b/flint/prefect/flows/bandpass_pipeline.py
@@ -247,6 +247,8 @@ def calibrate_bandpass_flow(
         model_path=model_path,
         source_name_prefix=source_name_prefix,
         skip_rotation=True,
+        smooth_window_size=smooth_window_size,
+        smooth_polynomial_order=smooth_polynomial_order,
     )
 
     return output_split_bandpass_path

--- a/flint/prefect/flows/bandpass_pipeline.py
+++ b/flint/prefect/flows/bandpass_pipeline.py
@@ -349,7 +349,7 @@ def get_parser() -> ArgumentParser:
         help="Path to a cluster configuration file, or a known cluster name. ",
     )
     parser.add_argument(
-        "--smoth-window-size",
+        "--smooth-window-size",
         default=16,
         type=int,
         help="Size of the smoothing Savgol window when smoothing bandpass solutions",

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -129,18 +129,18 @@ def process_science_fields(
         ms=preprocess_science_mss, container=field_options.flagger_container, rounds=1
     )
 
+    if field_options.no_imaging:
+        logger.info(
+            f"No imaging will be performed, as requested bu {field_options.no_imaging=}"
+        )
+        return
+
     field_summary = task_create_field_summary.submit(
         mss=flagged_mss,
         cal_sbid_path=bandpass_path,
         holography_path=field_options.holofile,
     )
     logger.info(f"{field_summary=}")
-
-    if field_options.no_imaging:
-        logger.info(
-            f"No imaging will be performed, as requested bu {field_options.no_imaging=}"
-        )
-        return
 
     if field_options.wsclean_container is None:
         logger.info("No wsclean container provided. Rerutning. ")

--- a/flint/summary.py
+++ b/flint/summary.py
@@ -108,7 +108,8 @@ def add_ms_summaries(
     Returns:
         Tuple[MSSummary]: Results from the inspected set of measurement sets
     """
-
+    logger.info("Adding MS summaries")
+    
     ms_summaries = tuple(map(describe_ms, mss))
     centre = estimate_skycoord_centre(
         sky_positions=concatenate([ms_summary.phase_dir for ms_summary in ms_summaries])

--- a/tests/test_aocalibrate.py
+++ b/tests/test_aocalibrate.py
@@ -9,6 +9,7 @@ import pytest
 
 from flint.bptools.smoother import (
     divide_bandpass_by_ref_ant,
+    divide_bandpass_by_ref_ant_preserve_phase,
     smooth_bandpass_complex_gains,
     smooth_data,
 )
@@ -232,6 +233,25 @@ def test_aosols_bandpass_ref_nu(ao_sols):
     )
     assert np.allclose(expected, complex_gains[0, :5, 0])
 
+
+def test_aosols_bandpass_ref_nu_preserve_phase(ao_sols):
+    ao = AOSolutions.load(path=ao_sols)
+
+    complex_gains = divide_bandpass_by_ref_ant_preserve_phase(complex_gains=ao.bandpass[0], ref_ant=0)
+
+    x_angle = np.angle(complex_gains[0,:,0])
+    y_angle = np.angle(complex_gains[0,:,3])
+
+    assert np.allclose(x_angle[np.isfinite(x_angle)], 0) 
+    assert np.allclose(y_angle[np.isfinite(y_angle)], 0)
+    
+    expected = np.array(([-0.10846614-0.01465966j, -0.10776107-0.01495074j,
+       -0.10728749-0.01611982j, -0.10742277-0.01654671j]))
+    
+    print(expected)
+    print(complex_gains[1, :4, 0])
+    
+    assert np.allclose(expected, complex_gains[1, :4, 0])
 
 def test_ref_ant_selection(ao_sols):
     ao = AOSolutions.load(path=ao_sols)

--- a/tests/test_aocalibrate.py
+++ b/tests/test_aocalibrate.py
@@ -237,21 +237,32 @@ def test_aosols_bandpass_ref_nu(ao_sols):
 def test_aosols_bandpass_ref_nu_preserve_phase(ao_sols):
     ao = AOSolutions.load(path=ao_sols)
 
-    complex_gains = divide_bandpass_by_ref_ant_preserve_phase(complex_gains=ao.bandpass[0], ref_ant=0)
+    complex_gains = divide_bandpass_by_ref_ant_preserve_phase(
+        complex_gains=ao.bandpass[0], ref_ant=0
+    )
 
-    x_angle = np.angle(complex_gains[0,:,0])
-    y_angle = np.angle(complex_gains[0,:,3])
+    x_angle = np.angle(complex_gains[0, :, 0])
+    y_angle = np.angle(complex_gains[0, :, 3])
 
-    assert np.allclose(x_angle[np.isfinite(x_angle)], 0) 
+    assert np.allclose(x_angle[np.isfinite(x_angle)], 0)
     assert np.allclose(y_angle[np.isfinite(y_angle)], 0)
-    
-    expected = np.array(([-0.10846614-0.01465966j, -0.10776107-0.01495074j,
-       -0.10728749-0.01611982j, -0.10742277-0.01654671j]))
-    
+
+    expected = np.array(
+        (
+            [
+                -0.10846614 - 0.01465966j,
+                -0.10776107 - 0.01495074j,
+                -0.10728749 - 0.01611982j,
+                -0.10742277 - 0.01654671j,
+            ]
+        )
+    )
+
     print(expected)
     print(complex_gains[1, :4, 0])
-    
+
     assert np.allclose(expected, complex_gains[1, :4, 0])
+
 
 def test_ref_ant_selection(ao_sols):
     ao = AOSolutions.load(path=ao_sols)

--- a/tests/test_aocalibrate.py
+++ b/tests/test_aocalibrate.py
@@ -123,6 +123,22 @@ def test_known_bad_sols(ao_sols_known_bad):
     flag_aosolutions(solutions_path=ao_sols_known_bad, plot_solutions_throughout=False)
 
 
+def test_sols_same_with_plots(ao_sols_known_bad):
+    # Had a thought at one point the plktting was updating th mutable numpy array before
+    # it was writen back to file. Wrote the test, and it passed. Test stays
+    a = flag_aosolutions(
+        solutions_path=ao_sols_known_bad, plot_solutions_throughout=False
+    )
+    a_loaded = AOSolutions.load(a.path)
+
+    b = flag_aosolutions(
+        solutions_path=ao_sols_known_bad, plot_solutions_throughout=True
+    )
+    b_loaded = AOSolutions.load(b.path)
+
+    assert np.allclose(a_loaded.bandpass, b_loaded.bandpass, equal_nan=True)
+
+
 def test_flagged_aosols(ao_sols_known_bad):
     flagged_sols = flag_aosolutions(
         solutions_path=ao_sols_known_bad,

--- a/tests/test_bandpass_flow.py
+++ b/tests/test_bandpass_flow.py
@@ -1,0 +1,28 @@
+"""Basic tests for the prefect bandpass flow
+"""
+
+# this pirate made a promise that if there is a typo and an error
+# then a test will be made to not let it happen. Penaalty is walking
+# the plank
+
+from flint.prefect.flows.bandpass_pipeline import get_parser
+
+
+def test_parser():
+    parser = get_parser()
+
+    args = parser.parse_args(
+        """/51998 
+        --calibrate-container /scratch3/gal16b/containers/calibrate.sif 
+        --flagger-container /scratch3/gal16b/containers/aoflagger.sif  
+        --cluster-config /scratch3/gal16b/bp_test/petrichor.yaml 
+        --split-path $(pwd) 
+        --smooth-window-size 8 
+        --smooth-polynomial-order 3
+    """.split()
+    )
+
+    assert args.smooth_polynomial_order == 3
+    assert args.smooth_window_size == 8
+    assert isinstance(args.smooth_window_size, int)
+    assert isinstance(args.smooth_polynomial_order, int)


### PR DESCRIPTION
The bandpass is solved for using `calibrate`, which solves for antenna Jones matrices. Each time and frequency step is solved for independently. As such, there is an unknown ambiguity within each Jones that is not necessarily the same between each independent set of solutions. 

`calibrate` does not set / enforce solutions with respect to a reference antenna. Attempts to smooth (or even average) components of the Jones across these independently optimised boundaries will result in error.  See arxiv.org/abs/1209.5492. 

The original attempt to set a phase reference antenna to the solutions was close, but wrong. This pull request is the adventure onto the correct solution. 