### PR TITLE
Add a flag -> calibrate -> flag loop to bandpass calibration

### DIFF
--- a/flint/calibrate/aocalibrate.py
+++ b/flint/calibrate/aocalibrate.py
@@ -685,6 +685,9 @@ def create_apply_solutions_cmd(
     if container is not None:
         run_apply_solutions(apply_solutions_cmd=apply_solutions, container=container)
 
+    # TODO: If outputcolumn is not CORRECTED_DATA then it should be renamed
+    # applysolutions always calls it CORRECTED_DATA
+
     return apply_solutions
 
 

--- a/flint/calibrate/aocalibrate.py
+++ b/flint/calibrate/aocalibrate.py
@@ -569,7 +569,7 @@ def create_calibrate_cmd(
     solution_path: Optional[Path] = None,
     container: Optional[Path] = None,
     update_calibrate_options: Optional[Dict[str, Any]] = None,
-    calibrate_data_column: Optional[str] = None
+    calibrate_data_column: Optional[str] = None,
 ) -> CalibrateCommand:
     """Generate a typical ao calibrate command. Any extra keyword arguments
     are passed through as additional options to the `calibrate` program.
@@ -580,7 +580,7 @@ def create_calibrate_cmd(
         solution_path (Path, optional): The output path of the calibrate solutions file. If None, a default suffix of "calibrate.bin" is used. Defaults to None.
         container (Optional[Path], optional): If a path to a container is supplied the calibrate command is executed immediatedly. Defaults to None.
         update_calibrate_options (Optional[Dict[str, Any]], optional): Additional options to update the generated CalibrateOptions with. Keys should be attributes of CalibrationOptions. Defaults ot None.
-        calibrate_data_column(Optional[str], optional): The name of the column to calibrate, overwritting the nominated column set in the MS. If None, the MS.column atribute is used. Defaults to None. 
+        calibrate_data_column(Optional[str], optional): The name of the column to calibrate, overwritting the nominated column set in the MS. If None, the MS.column atribute is used. Defaults to None.
 
     Raises:
         FileNotFoundError: Raised when calibrate_model can not be found.
@@ -590,11 +590,13 @@ def create_calibrate_cmd(
     """
     ms = MS.cast(ms)
 
-    column = ms.column 
+    column = ms.column
     if calibrate_data_column:
-        logger.info(f"Overwritting column to calibrate from {ms.column=} to {calibrate_data_column=}")
+        logger.info(
+            f"Overwritting column to calibrate from {ms.column=} to {calibrate_data_column=}"
+        )
         column = calibrate_data_column
-    
+
     assert column is not None, f"{ms} does not have a nominated data_column"
 
     logger.info(f"Creating calibrate command for {ms.path}")
@@ -663,7 +665,7 @@ def create_apply_solutions_cmd(
     """
     # extract the ms property, if required
     ms = MS.cast(ms)
-    
+
     assert ms.path.exists(), f"The measurement set {ms} was not found. "
     assert ms.column is not None, f"{ms} does not have a nominated data_column. "
     assert (

--- a/flint/flagging.py
+++ b/flint/flagging.py
@@ -22,11 +22,12 @@ class AOFlaggerCommand(NamedTuple):
     """The command that will be executed"""
     ms_path: Path
     """The path to the MS that will be flagged. """
-    ms: MS 
+    ms: MS
     """The MS object that was flagged"""
     strategy_file: Optional[Path] = None
     """The path to the aoflagging stategy file to use"""
-    
+
+
 def nan_zero_extreme_flag_ms(
     ms: Union[Path, MS],
     data_column: Optional[str] = None,

--- a/flint/flagging.py
+++ b/flint/flagging.py
@@ -22,10 +22,11 @@ class AOFlaggerCommand(NamedTuple):
     """The command that will be executed"""
     ms_path: Path
     """The path to the MS that will be flagged. """
+    ms: MS 
+    """The MS object that was flagged"""
     strategy_file: Optional[Path] = None
     """The path to the aoflagging stategy file to use"""
-
-
+    
 def nan_zero_extreme_flag_ms(
     ms: Union[Path, MS],
     data_column: Optional[str] = None,
@@ -122,6 +123,7 @@ def create_aoflagger_cmd(ms: MS) -> AOFlaggerCommand:
         AOFlaggerCommand: The aoflagger command that will be run
     """
     logger.info("Creating an AOFlagger command. ")
+    ms = MS.cast(ms)
 
     assert (
         ms.column is not None
@@ -138,7 +140,7 @@ def create_aoflagger_cmd(ms: MS) -> AOFlaggerCommand:
     cmd = f"aoflagger -column {ms.column} -strategy {flagging_strategy} -v {str(ms.path.absolute())}"
 
     return AOFlaggerCommand(
-        cmd=cmd, ms_path=ms.path, strategy_file=Path(flagging_strategy)
+        cmd=cmd, ms_path=ms.path, strategy_file=Path(flagging_strategy), ms=ms
     )
 
 
@@ -175,6 +177,7 @@ def flag_ms_aoflagger(ms: MS, container: Path, rounds: int = 1) -> MS:
     Returns:
         MS: Measurement set flagged with the appropriate column
     """
+    ms = MS.cast(ms)
     logger.info(f"Will flag column {ms.column} in {str(ms.path)}.")
     aoflagger_cmd = create_aoflagger_cmd(ms=ms)
 

--- a/flint/options.py
+++ b/flint/options.py
@@ -5,14 +5,39 @@ set of flint processing related options.
 from pathlib import Path
 from typing import NamedTuple, Optional
 
+class BandpassOptions(NamedTuple):
+    """Container that reoresents the flint related options that
+    might be used throughout the processing of bandpass calibration
+    data. 
+    
+    In its present form this `BandpassOptions` class is not intended
+    to contain properties of the data that arebeing processed, rather 
+    how these data will be processed. 
+    
+    These settings are not meant to be adjustabled throughout 
+    a single bandpass pipeline run
+    """
+    
+    flagger_container: Path
+    """Path to the singularity aoflagger container"""
+    calibrate_container: Path
+    """Path to the singularity calibrate container"""
+    expected_ms: int = 36
+    """The expected number of measurement set files to find"""
+    smooth_window_size: int = 16
+    """The width of the smoothing window used to smooth the bandpass solutions"""
+    smooth_polynomial_order: int = 4
+    """The polynomial order used by the Savgol filter when smoothing the bandpass solutions"""
+    flag_calibrate_rounds: int = 3 
+    """The number of times the bandpass will be calibrated, flagged, then recalibrated"""
 
 class FieldOptions(NamedTuple):
     """Container that represents the flint related options that
     might be used throughout components related to the actual
     pipeline.
 
-    In its present form this ``FieldOptions`` class is not intended
-    to container properties on the data that is being processed,
+    In its present form this `FieldOptions` class is not intended
+    to contain properties of the data that are being processed,
     rather how those data will be processed.
 
     These settins are not meant to be adjustable throughout

--- a/flint/options.py
+++ b/flint/options.py
@@ -5,19 +5,20 @@ set of flint processing related options.
 from pathlib import Path
 from typing import NamedTuple, Optional
 
+
 class BandpassOptions(NamedTuple):
     """Container that reoresents the flint related options that
     might be used throughout the processing of bandpass calibration
-    data. 
-    
+    data.
+
     In its present form this `BandpassOptions` class is not intended
-    to contain properties of the data that arebeing processed, rather 
-    how these data will be processed. 
-    
-    These settings are not meant to be adjustabled throughout 
+    to contain properties of the data that arebeing processed, rather
+    how these data will be processed.
+
+    These settings are not meant to be adjustabled throughout
     a single bandpass pipeline run
     """
-    
+
     flagger_container: Path
     """Path to the singularity aoflagger container"""
     calibrate_container: Path
@@ -28,8 +29,9 @@ class BandpassOptions(NamedTuple):
     """The width of the smoothing window used to smooth the bandpass solutions"""
     smooth_polynomial_order: int = 4
     """The polynomial order used by the Savgol filter when smoothing the bandpass solutions"""
-    flag_calibrate_rounds: int = 3 
+    flag_calibrate_rounds: int = 3
     """The number of times the bandpass will be calibrated, flagged, then recalibrated"""
+
 
 class FieldOptions(NamedTuple):
     """Container that represents the flint related options that

--- a/flint/prefect/flows/bandpass_pipeline.py
+++ b/flint/prefect/flows/bandpass_pipeline.py
@@ -170,7 +170,7 @@ def run_bandpass_stage(
     # Apply and then recalibrate
     apply_cmds = task_create_apply_solutions_cmd.map(
         ms=calibrate_cmds,
-        solutions_file=calibrate_cmds.solution_path,
+        solutions_file=calibrate_cmds,
         output_column="CORRECTED_DATA",
         container=calibrate_container,
     )

--- a/flint/prefect/flows/bandpass_pipeline.py
+++ b/flint/prefect/flows/bandpass_pipeline.py
@@ -166,6 +166,19 @@ def run_bandpass_stage(
         calibrate_model=model_path,
         container=calibrate_container,
     )
+
+    # Apply and then recalibrate
+    apply_cmds = task_create_apply_solutions_cmd.map(
+        ms=calibrate_cmds.ms,
+        solutions_file=calibrate_cmds.solution_path,
+        output_column="CORRECTED_DATA",
+        container=calibrate_container,
+    )
+    calibrate_cmds = task_create_calibrate_cmd.map(
+        ms=apply_cmds,
+        calibrate_model=model_path,
+        container=calibrate_container,
+    )
     flag_calibrate_cmds = task_flag_solutions.map(
         calibrate_cmd=calibrate_cmds,
         smooth_window_size=smooth_window_size,

--- a/flint/prefect/flows/bandpass_pipeline.py
+++ b/flint/prefect/flows/bandpass_pipeline.py
@@ -10,7 +10,7 @@ to split the correct field out before actually calibration.
 
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Collection, List
+from typing import Collection, List, Optional
 
 from prefect import flow, task
 
@@ -29,6 +29,7 @@ from flint.ms import MS, preprocess_askap_ms, split_by_field
 from flint.naming import get_sbid_from_path
 from flint.prefect.clusters import get_dask_runner
 from flint.prefect.common.utils import upload_image_as_artifact
+from flint.options import BandpassOptions
 from flint.sky_model import get_1934_model
 
 # These are generic functions that are wrapped. Their inputs are fairly standard
@@ -48,7 +49,7 @@ task_create_apply_solutions_cmd = task(create_apply_solutions_cmd)
 
 @task
 def task_bandpass_create_apply_solutions_cmd(
-    ms: MS, calibrate_cmd: CalibrateCommand, container: Path
+    ms: MS, calibrate_cmd: CalibrateCommand, container: Path, output_column: Optional[str] = None
 ) -> ApplySolutions:
     """Apply an ao-calibrate style solutions file to an input measurement set.
 
@@ -59,12 +60,13 @@ def task_bandpass_create_apply_solutions_cmd(
         ms (MS): The measurement set that will have solutions applied
         calibrate_cmd (CalibrateCommand): The calibrate command and meta-data describing the solutions to apply
         container (Path): Path to singularity container that will apply the solutions
+        output_column (Optional[Path], optional): the output column anme to create. Defaults to None. 
 
     Returns:
         ApplySolutions: The apply solutions command and meta-data
     """
     return create_apply_solutions_cmd(
-        ms=ms, solutions_file=calibrate_cmd.solution_path, container=container
+        ms=ms, solutions_file=calibrate_cmd.solution_path, output_column=output_column, container=container
     )
 
 
@@ -125,6 +127,7 @@ def run_bandpass_stage(
     skip_rotation: bool = False,
     smooth_window_size: int = 16,
     smooth_polynomial_order: int = 4,
+    flag_calibrate_rounds: int = 0
 ) -> List[CalibrateCommand]:
     """Excutes the bandpass calibration (using ``calibrate``) against a set of
     input measurement sets.
@@ -139,10 +142,13 @@ def run_bandpass_stage(
         skip_rotation (bool, optional): If ``True`` the rotation of the ASKAP visibility from the antenna frame to the sky-frame will be skipped. Defaults to False.
         smooth_window_size (int, optional): The size of the window function of the savgol filter. Passed directly to savgol. Defaults to 16.
         smooth_polynomial_order (int, optional): The order of the polynomial of the savgol filter. Passed directly to savgol. Defaults to 4.
+        flag_calibrate_rounds (int, optional): Defines the length of a loop that will calibrate, apply, flag and recalibrate. If 0, this is not performed. Defaults to 0. 
 
     Returns:
         List[CalibrateCommand]: Set of calibration commands used
     """
+    assert flag_calibrate_rounds >= 0, f"Currently {flag_calibrate_rounds=}, needs to be 0 or higher"
+
 
     if not output_split_bandpass_path.exists():
         logger.info(f"Creating {str(output_split_bandpass_path)}")
@@ -167,18 +173,23 @@ def run_bandpass_stage(
         container=calibrate_container,
     )
 
-    # Apply and then recalibrate
-    apply_cmds = task_create_apply_solutions_cmd.map(
-        ms=calibrate_cmds,
-        solutions_file=calibrate_cmds,
-        output_column="CORRECTED_DATA",
-        container=calibrate_container,
-    )
-    calibrate_cmds = task_create_calibrate_cmd.map(
-        ms=apply_cmds,
-        calibrate_model=model_path,
-        container=calibrate_container,
-    )
+    for i in range(flag_calibrate_rounds):
+        # Apply and then recalibrate
+        apply_cmds = task_bandpass_create_apply_solutions_cmd.map(
+            ms=calibrate_cmds,
+            calibrate_cmd=calibrate_cmds,
+            output_column="CORRECTED_DATA",
+            container=calibrate_container,
+        )
+        flag_bandpass_mss = task_flag_ms_aoflagger.map(
+            ms=apply_cmds, container=flagger_container, rounds=1
+        ) 
+        calibrate_cmds = task_create_calibrate_cmd.map(
+            ms=flag_bandpass_mss,
+            calibrate_model=model_path,
+            container=calibrate_container,
+            calibrate_data_column='DATA'
+        )
     flag_calibrate_cmds = task_flag_solutions.map(
         calibrate_cmd=calibrate_cmds,
         smooth_window_size=smooth_window_size,
@@ -192,11 +203,7 @@ def run_bandpass_stage(
 def calibrate_bandpass_flow(
     bandpass_path: Path,
     split_path: Path,
-    calibrate_container: Path,
-    flagger_container: Path,
-    expected_ms: int = 36,
-    smooth_window_size: int = 16,
-    smooth_polynomial_order: int = 4,
+    bandpass_options: BandpassOptions,
 ) -> Path:
     """Create and run the prefect flow to calibrate a set of bandpass measurement sets.
 
@@ -216,12 +223,8 @@ def calibrate_bandpass_flow(
     Args:
         bandpass_path (Path): Location to the folder containing the raw ASKAP bandpass measurement sets that will be calibrated
         split_path (Path): Location that will contain a folder, named after the SBID of the observation, that will contain the output bandpass measurement sets, solutions and plots
-        expected_ms (int): Expected numbner of measurement sets that should reside in the ``bandpass_path``
-        calibrate_container (Path): Path to a singularity container with the ao-calibrate tool
-        flagger_container (Path): Path to a singularity container with aoflaffer
-        smooth_window_size (int, optional): The size of the window function of the savgol filter. Passed directly to savgol. Defaults to 16.
-        wmooth_polynomial_order (int, optional): The order of the polynomial of the savgol filter. Passed directly to savgol. Defaults to 4.
-
+        bandpass_options (BandpassOptions): Options that specify configurables of the bandpass processing. 
+        
     Returns:
         Path: Directory that contains the extracted measurement sets and the ao-style gain solutions files.
     """
@@ -231,8 +234,8 @@ def calibrate_bandpass_flow(
     bandpass_mss = list([MS.cast(ms_path) for ms_path in bandpass_path.glob("*.ms")])
 
     assert (
-        len(bandpass_mss) == expected_ms
-    ), f"Expected to find {expected_ms} in {str(bandpass_path)}, found {len(bandpass_mss)}."
+        len(bandpass_mss) == bandpass_options.expected_ms
+    ), f"Expected to find {bandpass_options.expected_ms} in {str(bandpass_path)}, found {len(bandpass_mss)}."
 
     logger.info(
         f"Found the following bandpass measurement set: {[bp.path for bp in bandpass_mss]}."
@@ -255,13 +258,13 @@ def calibrate_bandpass_flow(
     run_bandpass_stage(
         bandpass_mss=bandpass_mss,
         output_split_bandpass_path=output_split_bandpass_path,
-        calibrate_container=calibrate_container,
-        flagger_container=flagger_container,
+        calibrate_container=bandpass_options.calibrate_container,
+        flagger_container=bandpass_options.flagger_container,
         model_path=model_path,
         source_name_prefix=source_name_prefix,
         skip_rotation=True,
-        smooth_window_size=smooth_window_size,
-        smooth_polynomial_order=smooth_polynomial_order,
+        smooth_window_size=bandpass_options.smooth_window_size,
+        smooth_polynomial_order=bandpass_options.smooth_polynomial_order,
     )
 
     return output_split_bandpass_path
@@ -270,12 +273,8 @@ def calibrate_bandpass_flow(
 def setup_run_bandpass_flow(
     bandpass_path: Path,
     split_path: Path,
-    expected_ms: int,
-    calibrate_container: Path,
-    flagger_container: Path,
     cluster_config: Path,
-    smooth_window_size: int = 16,
-    smooth_polynomial_order: int = 4,
+    bandpass_options: BandpassOptions
 ) -> Path:
     """Create and run the prefect flow to calibrate a set of bandpass measurement sets.
 
@@ -295,12 +294,8 @@ def setup_run_bandpass_flow(
     Args:
         bandpass_path (Path): Location to the folder containing the raw ASKAP bandpass measurement sets that will be calibrated
         split_path (Path): Location that will contain a folder, named after the SBID of the observation, that will contain the output bandpass measurement sets, solutions and plots
-        expected_ms (int): Expected numbner of measurement sets that should reside in the ``bandpass_path``
-        calibrate_container (Path): Path to a singularity container with the ao-calibrate tool
-        flagger_container (Path): Path to a singularity container with aoflaffer
         cluster_config (Path): Path to a yaml file that is used to configure a prefect dask task runner.
-        smooth_window_size (int, optional): The size of the window function of the savgol filter. Passed directly to savgol. Defaults to 16.
-        wmooth_polynomial_order (int, optional): The order of the polynomial of the savgol filter. Passed directly to savgol. Defaults to 4.
+        bandpass_options (BandpassOptions): Options that specify configurables of the bandpass processing. 
 
     Returns:
         Path: Directory that contains the extracted measurement sets and the ao-style gain solutions files.
@@ -315,11 +310,7 @@ def setup_run_bandpass_flow(
     )(
         bandpass_path=bandpass_path,
         split_path=split_path,
-        calibrate_container=calibrate_container,
-        flagger_container=flagger_container,
-        expected_ms=expected_ms,
-        smooth_window_size=smooth_window_size,
-        smooth_polynomial_order=smooth_polynomial_order,
+        bandpass_options=bandpass_options
     )
 
     return bandpass_path
@@ -383,6 +374,12 @@ def get_parser() -> ArgumentParser:
         type=int,
         help="Order of the polynomial when smoothing the bandpass solutions with the Savgol filter",
     )
+    parser.add_argument(
+        '--flag-calibrate-rounds',
+        type=int,
+        default=3,
+        help="The number of times a bandpass solution will be derived, applied and flagged. "
+    )
 
     return parser
 
@@ -396,15 +393,20 @@ def cli() -> None:
 
     args = parser.parse_args()
 
+    bandpass_options = BandpassOptions(
+        flagger_container=args.flagger_container,
+        calibrate_container=args.calibrate_container,
+        expected_ms=args.expected_ms,
+        smooth_window_size=args.smooth_window_size,
+        smooth_polynomial_order=args.smooth_polynomial_order,
+        flag_calibrate_rounds=args.flag_calibrate_rounds
+    )
+
     setup_run_bandpass_flow(
         bandpass_path=args.bandpass_path,
         split_path=args.split_path,
-        expected_ms=args.expected_ms,
-        calibrate_container=args.calibrate_container,
-        flagger_container=args.flagger_container,
         cluster_config=args.cluster_config,
-        smooth_window_size=args.smooth_window_size,
-        smooth_polynomial_order=args.smooth_polynomial_order,
+        bandpass_options=bandpass_options
     )
 
 

--- a/flint/prefect/flows/bandpass_pipeline.py
+++ b/flint/prefect/flows/bandpass_pipeline.py
@@ -265,6 +265,7 @@ def calibrate_bandpass_flow(
         skip_rotation=True,
         smooth_window_size=bandpass_options.smooth_window_size,
         smooth_polynomial_order=bandpass_options.smooth_polynomial_order,
+        flag_calibrate_rounds=bandpass_options.flag_calibrate_rounds
     )
 
     return output_split_bandpass_path

--- a/flint/prefect/flows/bandpass_pipeline.py
+++ b/flint/prefect/flows/bandpass_pipeline.py
@@ -169,7 +169,7 @@ def run_bandpass_stage(
 
     # Apply and then recalibrate
     apply_cmds = task_create_apply_solutions_cmd.map(
-        ms=calibrate_cmds.ms,
+        ms=calibrate_cmds,
         solutions_file=calibrate_cmds.solution_path,
         output_column="CORRECTED_DATA",
         container=calibrate_container,


### PR DESCRIPTION
To date flagging performed by `aoflagger` has been carried out against the uncalibrated visibility data, from which calibration was then performed. There was not attempt to iterate over this process. 

Inspecting the calibrated visibility data of 3C286 showed some spiky features. Revisiting the bandpass calibration and flagging further after an initial set of solutions were applied helped to minimise or remove these artefacts in 3C286. 

This change adds a loop to control how many times this process should be carried out. 

This is the spectrum of 3C286 when flagging on just the uncalibrated visibilities during bandpass calibration 

![Screen Shot 2024-02-20 at 16 01 07](https://github.com/tjgalvin/flint/assets/10543142/9af5ace0-a3ef-4e80-9652-03945210365a)

and this is after 5 rounds. Excessive, perhaps. 

![Screen Shot 2024-02-20 at 16 01 49](https://github.com/tjgalvin/flint/assets/10543142/ec32faae-ba38-44a4-9832-6ed1cb040eba)

