### PR TITLE
Switch flagging preprocessing order / exposing minuv calibrate option

### DIFF
--- a/flint/calibrate/aocalibrate.py
+++ b/flint/calibrate/aocalibrate.py
@@ -204,8 +204,9 @@ def plot_solutions(
         logger.info(f"Overwriting reference antenna selection, using {ref_ant=}")
 
     if ref_ant is not None:
-        # TODO: This is going to change the amplitudes as well. This is likely not wanted!
-        data = data / ao_sols.bandpass[plot_sol, ref_ant, :, :]
+        data = divide_bandpass_by_ref_ant_preserve_phase(
+            complex_gains=ao_sols.bandpass[plot_sol], ref_ant=ref_ant
+        )
 
     amplitudes = np.abs(data)
     phases = np.angle(data, deg=True)

--- a/flint/options.py
+++ b/flint/options.py
@@ -31,6 +31,8 @@ class BandpassOptions(NamedTuple):
     """The polynomial order used by the Savgol filter when smoothing the bandpass solutions"""
     flag_calibrate_rounds: int = 3
     """The number of times the bandpass will be calibrated, flagged, then recalibrated"""
+    minuv: Optional[float] = None
+    """The minimum baseline length, in meters, for data to be included in bandpass calibration stage"""
 
 
 class FieldOptions(NamedTuple):

--- a/flint/prefect/flows/bandpass_pipeline.py
+++ b/flint/prefect/flows/bandpass_pipeline.py
@@ -277,6 +277,7 @@ def calibrate_bandpass_flow(
         smooth_window_size=bandpass_options.smooth_window_size,
         smooth_polynomial_order=bandpass_options.smooth_polynomial_order,
         flag_calibrate_rounds=bandpass_options.flag_calibrate_rounds,
+        minuv=bandpass_options.minuv,
     )
 
     return output_split_bandpass_path

--- a/flint/prefect/flows/bandpass_pipeline.py
+++ b/flint/prefect/flows/bandpass_pipeline.py
@@ -12,7 +12,7 @@ from argparse import ArgumentParser
 from pathlib import Path
 from typing import Collection, List, Optional
 
-from prefect import flow, task
+from prefect import flow, task, unmapped
 
 from flint.bandpass import extract_correct_bandpass_pointing
 from flint.calibrate.aocalibrate import (
@@ -180,7 +180,7 @@ def run_bandpass_stage(
         ms=flag_bandpass_mss,
         calibrate_model=model_path,
         container=calibrate_container,
-        update_calibrate_options=dict(minuv=minuv),
+        update_calibrate_options=unmapped(dict(minuv=minuv)),
     )
 
     for i in range(flag_calibrate_rounds):
@@ -199,7 +199,7 @@ def run_bandpass_stage(
             calibrate_model=model_path,
             container=calibrate_container,
             calibrate_data_column="DATA",
-            update_calibrate_options=dict(minuv=minuv),
+            update_calibrate_options=unmapped(dict(minuv=minuv)),
         )
     flag_calibrate_cmds = task_flag_solutions.map(
         calibrate_cmd=calibrate_cmds,

--- a/flint/prefect/flows/bandpass_pipeline.py
+++ b/flint/prefect/flows/bandpass_pipeline.py
@@ -134,6 +134,7 @@ def run_bandpass_stage(
     smooth_window_size: int = 16,
     smooth_polynomial_order: int = 4,
     flag_calibrate_rounds: int = 0,
+    minuv: Optional[float] = None,
 ) -> List[CalibrateCommand]:
     """Excutes the bandpass calibration (using ``calibrate``) against a set of
     input measurement sets.
@@ -149,6 +150,7 @@ def run_bandpass_stage(
         smooth_window_size (int, optional): The size of the window function of the savgol filter. Passed directly to savgol. Defaults to 16.
         smooth_polynomial_order (int, optional): The order of the polynomial of the savgol filter. Passed directly to savgol. Defaults to 4.
         flag_calibrate_rounds (int, optional): Defines the length of a loop that will calibrate, apply, flag and recalibrate. If 0, this is not performed. Defaults to 0.
+        minuv (Optional[float], optional): The minimum baseline length, in meters, for data to be included in bandpass calibration stage. Defaults to None.
 
     Returns:
         List[CalibrateCommand]: Set of calibration commands used
@@ -178,6 +180,7 @@ def run_bandpass_stage(
         ms=flag_bandpass_mss,
         calibrate_model=model_path,
         container=calibrate_container,
+        update_calibrate_options=dict(minuv=minuv),
     )
 
     for i in range(flag_calibrate_rounds):
@@ -196,6 +199,7 @@ def run_bandpass_stage(
             calibrate_model=model_path,
             container=calibrate_container,
             calibrate_data_column="DATA",
+            update_calibrate_options=dict(minuv=minuv),
         )
     flag_calibrate_cmds = task_flag_solutions.map(
         calibrate_cmd=calibrate_cmds,
@@ -388,6 +392,12 @@ def get_parser() -> ArgumentParser:
         default=3,
         help="The number of times a bandpass solution will be derived, applied and flagged. ",
     )
+    parser.add_argument(
+        "--minuv",
+        type=float,
+        default=None,
+        help="The minimum baseline length, in meters, for data to be included in bandpass calibration stage",
+    )
 
     return parser
 
@@ -408,6 +418,7 @@ def cli() -> None:
         smooth_window_size=args.smooth_window_size,
         smooth_polynomial_order=args.smooth_polynomial_order,
         flag_calibrate_rounds=args.flag_calibrate_rounds,
+        minuv=args.minuv,
     )
 
     setup_run_bandpass_flow(


### PR DESCRIPTION
Reordered when aoflagger is run within the pipeline flow. Previously it was after the preprocessing operation, which includes the rotation to the sky-frame. Now it is before the rotation to the sky. 

Also exposed the calibrate minuv option to the main command line interface for the bandpass flow. 