### PR TITLE
Construct clean mask from previous beam image

### DIFF
--- a/flint/configuration.py
+++ b/flint/configuration.py
@@ -61,7 +61,7 @@ def get_image_options_from_yaml(
 
     if not self_cal_rounds:
         return {
-            "size": 7144,
+            "size": 5144,
             "minuvw_m": 235,
             "weight": "briggs -1.5",
             "scale": "2.5arcsec",
@@ -77,7 +77,7 @@ def get_image_options_from_yaml(
     else:
         return {
             1: {
-                "size": 7144,
+                "size": 5144,
                 "weight": "briggs -1.5",
                 "scale": "2.5arcsec",
                 "nmiter": 20,
@@ -90,7 +90,7 @@ def get_image_options_from_yaml(
                 "multiscale_scales": (0, 15, 30, 40, 50, 60, 70, 120, 240, 480),
             },
             2: {
-                "size": 7144,
+                "size": 5144,
                 "weight": "briggs -1.5",
                 "scale": "2.5arcsec",
                 "multiscale": True,
@@ -104,7 +104,7 @@ def get_image_options_from_yaml(
                 "multiscale_scales": (0, 15, 30, 40, 50, 60, 70, 120, 240, 480),
             },
             3: {
-                "size": 7144,
+                "size": 5144,
                 "weight": "briggs -1.5",
                 "scale": "2.5arcsec",
                 "multiscale": True,
@@ -118,7 +118,7 @@ def get_image_options_from_yaml(
                 "multiscale_scales": (0, 15, 30, 40, 50, 60, 70, 120, 240, 480),
             },
             4: {
-                "size": 7144,
+                "size": 5144,
                 "weight": "briggs -1.5",
                 "scale": "2.5arcsec",
                 "multiscale": True,
@@ -132,7 +132,7 @@ def get_image_options_from_yaml(
                 "multiscale_scales": (0, 15, 30, 40, 50, 60, 70, 120, 240, 480),
             },
             5: {
-                "size": 7144,
+                "size": 5144,
                 "weight": "briggs -1.5",
                 "scale": "2.5arcsec",
                 "multiscale": True,

--- a/flint/configuration.py
+++ b/flint/configuration.py
@@ -34,10 +34,9 @@ def get_selfcal_options_from_yaml(input_yaml: Optional[Path] = None) -> Dict:
     return {
         1: {"solint": "60s", "uvrange": ">235m", "nspw": 1},
         2: {"solint": "30s", "calmode": "p", "uvrange": ">235m", "nspw": 1},
-        3: {"solint": "10s", "calmode": "p", "uvrange": ">235m", "nspw": 1},
-        4: {"solint": "120s", "calmode": "ap", "uvrange": ">235m", "nspw": 1},
-        5: {"solint": "60s", "calmode": "ap", "uvrange": ">235m", "nspw": 1},
-        6: {"solint": "30s", "calmode": "ap", "uvrange": ">235m", "nspw": 1},
+        3: {"solint": "120s", "calmode": "ap", "uvrange": ">235m", "nspw": 1},
+        4: {"solint": "60s", "calmode": "ap", "uvrange": ">235m", "nspw": 1},
+        5: {"solint": "30s", "calmode": "ap", "uvrange": ">235m", "nspw": 1},
     }
 
 

--- a/flint/configuration.py
+++ b/flint/configuration.py
@@ -60,7 +60,7 @@ def get_image_options_from_yaml(
     ), "Configuring via a yaml configuration file is not yet support. "
 
     MULTISCALE_SCALES = (0, 15, 30, 40, 50, 60, 70, 120)
-    IMAGE_SIZE = 9144
+    IMAGE_SIZE = 7144
 
     if not self_cal_rounds:
         return {

--- a/flint/configuration.py
+++ b/flint/configuration.py
@@ -59,9 +59,12 @@ def get_image_options_from_yaml(
         input_yaml is None
     ), "Configuring via a yaml configuration file is not yet support. "
 
+    MULTISCALE_SCALES = (0, 15, 30, 40, 50, 60, 70, 120, 240, 480)
+    IMAGE_SIZE = 9144
+
     if not self_cal_rounds:
         return {
-            "size": 5144,
+            "size": IMAGE_SIZE,
             "minuvw_m": 235,
             "weight": "briggs -1.5",
             "scale": "2.5arcsec",
@@ -72,12 +75,12 @@ def get_image_options_from_yaml(
             "auto_mask": 10,
             "multiscale": True,
             "local_rms_window": 55,
-            "multiscale_scales": (0, 15, 30, 40, 50, 60, 70, 120, 240, 480),
+            "multiscale_scales": MULTISCALE_SCALES,
         }
     else:
         return {
             1: {
-                "size": 5144,
+                "size": IMAGE_SIZE,
                 "weight": "briggs -1.5",
                 "scale": "2.5arcsec",
                 "nmiter": 20,
@@ -87,10 +90,10 @@ def get_image_options_from_yaml(
                 "fit_spectral_pol": 3,
                 "auto_mask": 8.0,
                 "local_rms_window": 55,
-                "multiscale_scales": (0, 15, 30, 40, 50, 60, 70, 120, 240, 480),
+                "multiscale_scales": MULTISCALE_SCALES,
             },
             2: {
-                "size": 5144,
+                "size": IMAGE_SIZE,
                 "weight": "briggs -1.5",
                 "scale": "2.5arcsec",
                 "multiscale": True,
@@ -101,10 +104,10 @@ def get_image_options_from_yaml(
                 "fit_spectral_pol": 3,
                 "auto_mask": 7.0,
                 "local_rms_window": 55,
-                "multiscale_scales": (0, 15, 30, 40, 50, 60, 70, 120, 240, 480),
+                "multiscale_scales": MULTISCALE_SCALES,
             },
             3: {
-                "size": 5144,
+                "size": IMAGE_SIZE,
                 "weight": "briggs -1.5",
                 "scale": "2.5arcsec",
                 "multiscale": True,
@@ -115,10 +118,10 @@ def get_image_options_from_yaml(
                 "fit_spectral_pol": 3,
                 "auto_mask": 6.0,
                 "local_rms_window": 55,
-                "multiscale_scales": (0, 15, 30, 40, 50, 60, 70, 120, 240, 480),
+                "multiscale_scales": MULTISCALE_SCALES,
             },
             4: {
-                "size": 5144,
+                "size": IMAGE_SIZE,
                 "weight": "briggs -1.5",
                 "scale": "2.5arcsec",
                 "multiscale": True,
@@ -129,10 +132,10 @@ def get_image_options_from_yaml(
                 "fit_spectral_pol": 3,
                 "auto_mask": 8,
                 "local_rms_window": 55,
-                "multiscale_scales": (0, 15, 30, 40, 50, 60, 70, 120, 240, 480),
+                "multiscale_scales": MULTISCALE_SCALES,
             },
             5: {
-                "size": 5144,
+                "size": IMAGE_SIZE,
                 "weight": "briggs -1.5",
                 "scale": "2.5arcsec",
                 "multiscale": True,
@@ -143,7 +146,7 @@ def get_image_options_from_yaml(
                 "fit_spectral_pol": 3,
                 "auto_mask": 7.0,
                 "local_rms_window": 55,
-                "multiscale_scales": (0, 15, 30, 40, 50, 60, 70, 120, 240, 480),
+                "multiscale_scales": MULTISCALE_SCALES,
             },
         }
 

--- a/flint/configuration.py
+++ b/flint/configuration.py
@@ -3,6 +3,7 @@ configuration file. The idea being that a configuration file would
 be used to specify the options for imaging and self-calibration
 throughout the pipeline.
 """
+
 from argparse import ArgumentParser
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -12,6 +13,140 @@ import yaml
 from flint.imager.wsclean import WSCleanOptions
 from flint.logging import logger
 from flint.selfcal.casa import GainCalOptions
+
+
+def get_selfcal_options_from_yaml(input_yaml: Optional[Path] = None) -> Dict:
+    """Stub to represent interaction with a configurationf ile
+
+    If a path is supplied, an error is raised.
+
+    Args:
+        input_yaml (Optional[Path], optional): Path to the configuration file. . Defaults to Optional[Path]=None.
+
+    Returns:
+        Dict: Mapping where the key is the self-calibration round, and values are key-value of updated gaincal options
+    """
+
+    assert (
+        input_yaml is None
+    ), "Configuring via a yaml configuration file is not yet support. "
+
+    return {
+        1: {"solint": "60s", "uvrange": ">235m", "nspw": 1},
+        2: {"solint": "30s", "calmode": "p", "uvrange": ">235m", "nspw": 1},
+        3: {"solint": "10s", "calmode": "p", "uvrange": ">235m", "nspw": 1},
+        4: {"solint": "120s", "calmode": "ap", "uvrange": ">235m", "nspw": 1},
+        5: {"solint": "60s", "calmode": "ap", "uvrange": ">235m", "nspw": 1},
+        6: {"solint": "30s", "calmode": "ap", "uvrange": ">235m", "nspw": 1},
+    }
+
+
+def get_image_options_from_yaml(
+    input_yaml: Optional[Path] = None, self_cal_rounds: bool = False
+) -> Dict:
+    """Stub to interact with configuration file.
+
+    If a `input_yaml` file is provided an error is raised
+
+    Args:
+        input_yaml (Optional[Path], optional): Should be None. Defaults to None.
+        self_cal_rounds (bool, optional): Whether options for first imaging is being provided, or options to supply for each self-cal round. Defaults to False.
+
+    Returns:
+        Dict: _description_
+    """
+
+    assert (
+        input_yaml is None
+    ), "Configuring via a yaml configuration file is not yet support. "
+
+    if not self_cal_rounds:
+        return {
+            "size": 7144,
+            "minuvw_m": 235,
+            "weight": "briggs -1.5",
+            "scale": "2.5arcsec",
+            "nmiter": 10,
+            "force_mask_rounds": 10,
+            "deconvolution_channels": 4,
+            "fit_spectral_pol": 3,
+            "auto_mask": 10,
+            "multiscale": True,
+            "local_rms_window": 55,
+            "multiscale_scales": (0, 15, 30, 40, 50, 60, 70, 120, 240, 480),
+        }
+    else:
+        return {
+            1: {
+                "size": 7144,
+                "weight": "briggs -1.5",
+                "scale": "2.5arcsec",
+                "nmiter": 20,
+                "force_mask_rounds": 8,
+                "minuvw_m": 235,
+                "deconvolution_channels": 4,
+                "fit_spectral_pol": 3,
+                "auto_mask": 8.0,
+                "local_rms_window": 55,
+                "multiscale_scales": (0, 15, 30, 40, 50, 60, 70, 120, 240, 480),
+            },
+            2: {
+                "size": 7144,
+                "weight": "briggs -1.5",
+                "scale": "2.5arcsec",
+                "multiscale": True,
+                "minuvw_m": 235,
+                "nmiter": 20,
+                "force_mask_rounds": 8,
+                "deconvolution_channels": 4,
+                "fit_spectral_pol": 3,
+                "auto_mask": 7.0,
+                "local_rms_window": 55,
+                "multiscale_scales": (0, 15, 30, 40, 50, 60, 70, 120, 240, 480),
+            },
+            3: {
+                "size": 7144,
+                "weight": "briggs -1.5",
+                "scale": "2.5arcsec",
+                "multiscale": True,
+                "minuvw_m": 235,
+                "nmiter": 20,
+                "force_mask_rounds": 8,
+                "channels_out": 4,
+                "fit_spectral_pol": 3,
+                "auto_mask": 6.0,
+                "local_rms_window": 55,
+                "multiscale_scales": (0, 15, 30, 40, 50, 60, 70, 120, 240, 480),
+            },
+            4: {
+                "size": 7144,
+                "weight": "briggs -1.5",
+                "scale": "2.5arcsec",
+                "multiscale": True,
+                "minuvw_m": 235,
+                "nmiter": 20,
+                "force_mask_rounds": 10,
+                "channels_out": 4,
+                "fit_spectral_pol": 3,
+                "auto_mask": 8,
+                "local_rms_window": 55,
+                "multiscale_scales": (0, 15, 30, 40, 50, 60, 70, 120, 240, 480),
+            },
+            5: {
+                "size": 7144,
+                "weight": "briggs -1.5",
+                "scale": "2.5arcsec",
+                "multiscale": True,
+                "minuvw_m": 235,
+                "nmiter": 20,
+                "force_mask_rounds": 10,
+                "channels_out": 4,
+                "fit_spectral_pol": 3,
+                "auto_mask": 7.0,
+                "local_rms_window": 55,
+                "multiscale_scales": (0, 15, 30, 40, 50, 60, 70, 120, 240, 480),
+            },
+        }
 
 
 def load_yaml(input_yaml: Path) -> Any:

--- a/flint/configuration.py
+++ b/flint/configuration.py
@@ -34,8 +34,8 @@ def get_selfcal_options_from_yaml(input_yaml: Optional[Path] = None) -> Dict:
     return {
         1: {"solint": "60s", "uvrange": ">235m", "nspw": 1},
         2: {"solint": "30s", "calmode": "p", "uvrange": ">235m", "nspw": 1},
-        3: {"solint": "120s", "calmode": "ap", "uvrange": ">235m", "nspw": 1},
-        4: {"solint": "60s", "calmode": "ap", "uvrange": ">235m", "nspw": 1},
+        3: {"solint": "60s", "calmode": "ap", "uvrange": ">235m", "nspw": 4},
+        4: {"solint": "30s", "calmode": "ap", "uvrange": ">235m", "nspw": 4},
         5: {"solint": "30s", "calmode": "ap", "uvrange": ">235m", "nspw": 1},
     }
 
@@ -114,7 +114,8 @@ def get_image_options_from_yaml(
                 "minuvw_m": 235,
                 "nmiter": 20,
                 "force_mask_rounds": 8,
-                "channels_out": 4,
+                "channels_out": 16,
+                "deconvolution_channels": 4,
                 "fit_spectral_pol": 3,
                 "auto_mask": 6.0,
                 "local_rms_window": 55,
@@ -128,7 +129,8 @@ def get_image_options_from_yaml(
                 "minuvw_m": 235,
                 "nmiter": 20,
                 "force_mask_rounds": 10,
-                "channels_out": 4,
+                "channels_out": 16,
+                "deconvolution_channels": 4,
                 "fit_spectral_pol": 3,
                 "auto_mask": 8,
                 "local_rms_window": 55,

--- a/flint/configuration.py
+++ b/flint/configuration.py
@@ -59,7 +59,7 @@ def get_image_options_from_yaml(
         input_yaml is None
     ), "Configuring via a yaml configuration file is not yet support. "
 
-    MULTISCALE_SCALES = (0, 15, 30, 40, 50, 60, 70, 120, 240, 480)
+    MULTISCALE_SCALES = (0, 15, 30, 40, 50, 60, 70, 120)
     IMAGE_SIZE = 9144
 
     if not self_cal_rounds:

--- a/flint/options.py
+++ b/flint/options.py
@@ -94,5 +94,5 @@ class FieldOptions(NamedTuple):
     """Whether to apply (or search for solutions with) a bandpass smoothing operation applied"""
     use_beam_masks: bool = True
     """Construct beam masks from MFS images to use for the next round of imaging. """
-    use_beam_masks_from: int = 3
+    use_beam_masks_from: int = 2
     """If `use_beam_masks` is True, start using them from this round of self-calibration"""

--- a/flint/options.py
+++ b/flint/options.py
@@ -92,3 +92,7 @@ class FieldOptions(NamedTuple):
     """Whether to apply (or search for solutions with) bandpass solutions that have gone through the preflagging operations"""
     use_smoothed: bool = True
     """Whether to apply (or search for solutions with) a bandpass smoothing operation applied"""
+    use_beam_masks: bool = True
+    """Construct beam masks from MFS images to use for the next round of imaging. """
+    use_beam_masks_from: int = 3
+    """If `use_beam_masks` is True, start using them from this round of self-calibration"""

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -237,7 +237,9 @@ def task_wsclean_imager(
 
 @task
 def task_get_common_beam(
-    wsclean_cmds: Collection[WSCleanCommand], cutoff: float = 25, filter: Optional[str] = None
+    wsclean_cmds: Collection[WSCleanCommand],
+    cutoff: float = 25,
+    filter: Optional[str] = None,
 ) -> BeamShape:
     """Compute a common beam size that all input images will be convoled to.
 
@@ -245,7 +247,7 @@ def task_get_common_beam(
         wsclean_cmds (Collection[WSCleanCommand]): Input images whose restoring beam properties will be considered
         cutoff (float, optional): Major axis larger than this valur, in arcseconds, will be ignored. Defaults to 25.
         filter (Optional[str], optional): Only include images when considering beam shape if this string is in the file path. Defaults to None.
-        
+
     Returns:
         BeamShape: The final convolving beam size to be used
     """
@@ -261,7 +263,9 @@ def task_get_common_beam(
         images_to_consider.extend(wsclean_cmd.imageset.image)
 
     if filter:
-        images_to_consider = [image for image in images_to_consider if filter in str(image)]
+        images_to_consider = [
+            image for image in images_to_consider if filter in str(image)
+        ]
 
     logger.info(
         f"Considering {len(images_to_consider)} images across {len(wsclean_cmds)} outputs. "
@@ -278,7 +282,7 @@ def task_convolve_image(
     beam_shape: BeamShape,
     cutoff: float = 60,
     mode: str = "image",
-    filter: Optional[str] = None
+    filter: Optional[str] = None,
 ) -> Collection[Path]:
     """Convolve images to a specified resolution
 
@@ -286,7 +290,7 @@ def task_convolve_image(
         wsclean_cmd (WSCleanCommand): Collection of output images from wsclean that will be convolved
         beam_shape (BeamShape): The shape images will be convolved to
         cutoff (float, optional): Maximum major beam axis an image is allowed to have before it will not be convolved. Defaults to 60.
-        filter (Optional[str], optional): This string must be contained in the image path for it to be convolved. Defaults to None. 
+        filter (Optional[str], optional): This string must be contained in the image path for it to be convolved. Defaults to None.
 
     Returns:
         Collection[Path]: Path to the output images that have been convolved.
@@ -307,7 +311,9 @@ def task_convolve_image(
 
     if filter:
         logger.info(f"Filtering images paths with {filter=}")
-        image_paths = [image_path for image_path in image_paths if filter in str(image_path)]
+        image_paths = [
+            image_path for image_path in image_paths if filter in str(image_path)
+        ]
 
     # It is possible depending on how aggressively cleaning image products are deleted that these
     # some cleaning products (e.g. residuals) do not exist. There are a number of ways one could consider
@@ -438,7 +444,7 @@ def _convolve_linmos_residuals(
         beam_shape=unmapped(beam_shape),
         cutoff=150.0,
         mode="residual",
-        filter="-MFS-"
+        filter="-MFS-",
     )
     parset = task_linmos_images.submit(
         images=residual_conv_images,

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -237,14 +237,15 @@ def task_wsclean_imager(
 
 @task
 def task_get_common_beam(
-    wsclean_cmds: Collection[WSCleanCommand], cutoff: float = 25
+    wsclean_cmds: Collection[WSCleanCommand], cutoff: float = 25, filter: Optional[str] = None
 ) -> BeamShape:
     """Compute a common beam size that all input images will be convoled to.
 
     Args:
         wsclean_cmds (Collection[WSCleanCommand]): Input images whose restoring beam properties will be considered
         cutoff (float, optional): Major axis larger than this valur, in arcseconds, will be ignored. Defaults to 25.
-
+        filter (Optional[str], optional): Only include images when considering beam shape if this string is in the file path. Defaults to None.
+        
     Returns:
         BeamShape: The final convolving beam size to be used
     """
@@ -258,6 +259,9 @@ def task_get_common_beam(
             )
             continue
         images_to_consider.extend(wsclean_cmd.imageset.image)
+
+    if filter:
+        images_to_consider = [image for image in images_to_consider if filter in str(image)]
 
     logger.info(
         f"Considering {len(images_to_consider)} images across {len(wsclean_cmds)} outputs. "
@@ -274,6 +278,7 @@ def task_convolve_image(
     beam_shape: BeamShape,
     cutoff: float = 60,
     mode: str = "image",
+    filter: Optional[str] = None
 ) -> Collection[Path]:
     """Convolve images to a specified resolution
 
@@ -281,6 +286,7 @@ def task_convolve_image(
         wsclean_cmd (WSCleanCommand): Collection of output images from wsclean that will be convolved
         beam_shape (BeamShape): The shape images will be convolved to
         cutoff (float, optional): Maximum major beam axis an image is allowed to have before it will not be convolved. Defaults to 60.
+        filter (Optional[str], optional): This string must be contained in the image path for it to be convolved. Defaults to None. 
 
     Returns:
         Collection[Path]: Path to the output images that have been convolved.
@@ -298,6 +304,10 @@ def task_convolve_image(
     image_paths: Collection[Path] = (
         wsclean_cmd.imageset.image if mode == "image" else wsclean_cmd.imageset.residual
     )
+
+    if filter:
+        logger.info(f"Filtering images paths with {filter=}")
+        image_paths = [image_path for image_path in image_paths if filter in str(image_path)]
 
     # It is possible depending on how aggressively cleaning image products are deleted that these
     # some cleaning products (e.g. residuals) do not exist. There are a number of ways one could consider
@@ -428,6 +438,7 @@ def _convolve_linmos_residuals(
         beam_shape=unmapped(beam_shape),
         cutoff=150.0,
         mode="residual",
+        filter="-MFS-"
     )
     parset = task_linmos_images.submit(
         images=residual_conv_images,

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -492,7 +492,7 @@ def task_create_image_mask_model(
             fits_rms_path=source_rms,
             create_signal_fits=True,
             min_snr=min_snr,
-            connectivity_shape=(4, 4),
+            connectivity_shape=(3, 3),
         )
     else:
         mask_names = create_snr_mask_from_fits(

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -492,7 +492,7 @@ def task_create_image_mask_model(
             fits_rms_path=source_rms,
             create_signal_fits=True,
             min_snr=min_snr,
-            connectivity_shape=(2, 2),
+            connectivity_shape=(4, 4),
         )
     else:
         mask_names = create_snr_mask_from_fits(
@@ -621,3 +621,28 @@ def task_create_validation_tables(
                     )
 
     return validation_tables
+
+
+def _validation_items(field_summary: FieldSummary, aegean_outputs: AegeanOutputs, reference_catalogue_directory: Path):
+    """Construct the validation plot and validation table items for the imaged field. 
+
+    Internally these are submitting the prefect task versions of:
+    - `task_create_validation_plot` 
+    - `task_create_validation_tables`
+
+    Args:
+        field_summary (FieldSummary): Container representing the SBID being imaged and its populated characteristics
+        aegean_outputs (AegeanOutputs): Source finding results 
+        reference_catalogue_directory (Path): Location of directory containing the reference known NVSS, SUMSS and ICRS catalogues
+    """
+    
+    validation_plot = task_create_validation_plot.submit(
+        field_summary=field_summary,
+        aegean_outputs=aegean_outputs,
+        reference_catalogue_directory=reference_catalogue_directory,
+    )
+    validation_tables = task_create_validation_tables.submit(
+        field_summary=field_summary,
+        aegean_outputs=aegean_outputs,
+        reference_catalogue_directory=reference_catalogue_directory,
+    )

--- a/flint/prefect/flows/continuum_mask_pipeline.py
+++ b/flint/prefect/flows/continuum_mask_pipeline.py
@@ -12,6 +12,7 @@ the larger singnal linmos mask image using a template WCS header. It seems
 that the best way to do this would be to use a header from the preivous
 imaging round.
 """
+
 from argparse import ArgumentParser
 from pathlib import Path
 from typing import Any, Union

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -263,9 +263,11 @@ def process_science_fields(
             fits_beam_masks = task_create_image_mask_model.map(
                 image=wsclean_cmds,
                 image_products=beam_aegean_outputs,
-                min_snr=3.5,
+                min_snr=4,
                 with_butterworth=True,
             )
+            wsclean_options["auto_mask"] = 3
+            wsclean_options["local_rms"] = False
 
         wsclean_cmds = task_wsclean_imager.map(
             in_ms=cal_mss,

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -183,7 +183,7 @@ def process_science_fields(
         wsclean_cmd=wsclean_cmds,
         beam_shape=unmapped(beam_shape),
         cutoff=field_options.beam_cutoff,
-        filter="-MFS-"
+        filter="-MFS-",
     )
     if field_options.yandasoft_container:
         parset = task_linmos_images.submit(
@@ -268,8 +268,8 @@ def process_science_fields(
             wsclean_options["auto_mask"] = 1
             wsclean_options["force_mask_rounds"] = 18
             wsclean_options["local_rms"] = False
-            wsclean_options['niter'] = 1750000
-            wsclean_options['nmiter'] = 20
+            wsclean_options["niter"] = 1750000
+            wsclean_options["nmiter"] = 20
 
         wsclean_cmds = task_wsclean_imager.map(
             in_ms=cal_mss,
@@ -292,7 +292,7 @@ def process_science_fields(
             wsclean_cmd=wsclean_cmds,
             beam_shape=unmapped(beam_shape),
             cutoff=field_options.beam_cutoff,
-            filter="-MFS-"
+            filter="-MFS-",
         )
         if field_options.yandasoft_container is None:
             logger.info("No yandasoft container supplied, not linmosing. ")

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -492,7 +492,7 @@ def get_parser() -> ArgumentParser:
         help="If --use-beam-masks is provided, this option specifies from which round of self-calibration the masking operation will be used onwards from. ",
     )
     parser.add_argument(
-        "--use-beam_masks-wbutterworth",
+        "--use-beam-masks-wbutterworth",
         default=False,
         action="store_true",
         help="If --use-beam-masks is provided, this will specify whether a Butterworth filter is first used to smooth an image before applying the S/N cut",

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -264,6 +264,7 @@ def process_science_fields(
             )
             wsclean_options["auto_mask"] = 3
             wsclean_options["local_rms"] = False
+            wsclean_options['nmiter'] = 14
 
         wsclean_cmds = task_wsclean_imager.map(
             in_ms=cal_mss,

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -177,12 +177,13 @@ def process_science_fields(
         )
 
     beam_shape = task_get_common_beam.submit(
-        wsclean_cmds=wsclean_cmds, cutoff=field_options.beam_cutoff
+        wsclean_cmds=wsclean_cmds, cutoff=field_options.beam_cutoff, filter="-MFS-"
     )
     conv_images = task_convolve_image.map(
         wsclean_cmd=wsclean_cmds,
         beam_shape=unmapped(beam_shape),
         cutoff=field_options.beam_cutoff,
+        filter="-MFS-"
     )
     if field_options.yandasoft_container:
         parset = task_linmos_images.submit(
@@ -257,11 +258,11 @@ def process_science_fields(
                 min_snr=3.5,
                 with_butterworth=field_options.use_beam_mask_wbutterworth,
             )
-            wsclean_options["auto_mask"] = None
-            wsclean_options["force_mask_rounds"] = None
+            wsclean_options["auto_mask"] = 1
+            wsclean_options["force_mask_rounds"] = 18
             wsclean_options["local_rms"] = False
-            # wsclean_options['nmiter'] = 18
-            # wsclean_options['niter'] = 175000
+            wsclean_options['niter'] = 1750000
+            wsclean_options['nmiter'] = 20
 
         wsclean_cmds = task_wsclean_imager.map(
             in_ms=cal_mss,
@@ -278,12 +279,13 @@ def process_science_fields(
             )
 
         beam_shape = task_get_common_beam.submit(
-            wsclean_cmds=wsclean_cmds, cutoff=field_options.beam_cutoff
+            wsclean_cmds=wsclean_cmds, cutoff=field_options.beam_cutoff, filter="-MFS-"
         )
         conv_images = task_convolve_image.map(
             wsclean_cmd=wsclean_cmds,
             beam_shape=unmapped(beam_shape),
             cutoff=field_options.beam_cutoff,
+            filter="-MFS-"
         )
         if field_options.yandasoft_container is None:
             logger.info("No yandasoft container supplied, not linmosing. ")

--- a/flint/source_finding/aegean.py
+++ b/flint/source_finding/aegean.py
@@ -55,7 +55,7 @@ def run_bane_and_aegean(
     bane_command_str = f"BANE {str(image)} --cores {cores} --stripes {cores//2}"
     logger.info("Constructed BANE command. ")
 
-    bind_dir = [image.absolute()]
+    bind_dir = [image.absolute().parent]
     run_singularity_command(
         image=aegean_container, command=bane_command_str, bind_dirs=bind_dir
     )

--- a/flint/source_finding/aegean.py
+++ b/flint/source_finding/aegean.py
@@ -1,5 +1,6 @@
 """A basic interface into aegean source finding routines.
 """
+
 from argparse import ArgumentParser
 from pathlib import Path
 from typing import NamedTuple, Tuple
@@ -25,6 +26,8 @@ class AegeanOutputs(NamedTuple):
     """Source component catalogue created by Aegean"""
     beam_shape: Tuple[float, float, float]
     """The `BMAJ`, `BMIN` and `BPA` that were stored in the image header that Aegen searched"""
+    image: Path
+    """The input image that was used to source find against"""
 
 
 def run_bane_and_aegean(
@@ -86,6 +89,7 @@ def run_bane_and_aegean(
         rms=rms_image_path,
         comp=aegean_names.comp_cat,
         beam_shape=image_beam,
+        image=image,
     )
 
     logger.info(f"Aegeam finished running. {aegean_outputs=}")

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,0 +1,41 @@
+import pytest
+from pathlib import Path
+
+from flint.configuration import (
+    get_image_options_from_yaml,
+    get_selfcal_options_from_yaml,
+)
+
+
+def test_get_image_options():
+    init = get_image_options_from_yaml(input_yaml=None, self_cal_rounds=False)
+
+    assert isinstance(init, dict)
+
+    rounds = get_image_options_from_yaml(input_yaml=None, self_cal_rounds=True)
+
+    assert isinstance(init, dict)
+    assert 1 in rounds.keys()
+
+
+def test_raise_image_options_error():
+
+    example = Path("example.yaml")
+
+    with pytest.raises(AssertionError):
+        get_image_options_from_yaml(input_yaml=example)
+
+
+def test_self_cal_options():
+    rounds = get_selfcal_options_from_yaml(input_yaml=None)
+
+    assert isinstance(rounds, dict)
+    assert 1 in rounds.keys()
+
+
+def test_raise_error_options_error():
+
+    example = Path("example.yaml")
+
+    with pytest.raises(AssertionError):
+        get_selfcal_options_from_yaml(input_yaml=example)

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -37,7 +37,7 @@ def aegean_outputs_example():
     )
 
     aegean_outputs = AegeanOutputs(
-        bkg=rms, rms=rms, comp=comp, beam_shape=(1.0, 1.0, 1.0)
+        bkg=rms, rms=rms, comp=comp, beam_shape=(1.0, 1.0, 1.0), image=rms
     )
 
     return aegean_outputs


### PR DESCRIPTION
In an earlier pipeline experiment I wrote some code that would:
- linmos beams together to form a field image
- smooth the linmos'd field image (optional)
- construct a signal-to-noise map and apply a threshold
- extract a mask on a per-beam basis from the field image

The idea was to construct the beam-wise mask from the most sensitive image available. Although this worked (in a separate continuum prefect flow) there were a couple of practical issues around artefacts of the weighting process creeping into the image from sudden jobs in the model, and strange interactions with wsclean. In time this should be re-investigated with a fresh pair of eyes. 

This pull request is more or less the same idea, but only using the previous restored image as a source image from which the mask is constructed. To better assist with readability I have also started to make better use of the stub `configuration.py` interface. There have been some other quality of life changes around the masking functionality. 