### PR TITLE
Clean mask using reverse flood fill and negative sidelobe suppression

### DIFF
--- a/flint/masking.py
+++ b/flint/masking.py
@@ -149,8 +149,8 @@ def reverse_negative_flood_fill(
     positive_dilated_mask = scipy_binary_dilation(
         input=positive_mask,
         mask=signal > positive_flood_clip,
-        iterations=10,
-        structure=np.ones((4, 4)),
+        iterations=200,
+        structure=np.ones((3, 3)),
     )
 
     # Now do the same but on negative islands. The assumption here is that:
@@ -338,8 +338,8 @@ def create_snr_mask_from_fits(
     if attempt_reverse_nergative_flood_fill:
         mask_data = reverse_negative_flood_fill(
             signal=np.squeeze(signal_data),
-            positive_seed_clip=4,
-            positive_flood_clip=2,
+            positive_seed_clip=5,
+            positive_flood_clip=1.5,
             negative_seed_clip=4,
             guard_negative_dilation=40,
         )

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -115,7 +115,11 @@ def reverse_negative_flood_fill(
         np.ndarray: Mask of the pixels to clean
     """
 
-    logger.info("Will be reversing filling")
+    logger.info("Will be reversing flood filling")
+    logger.info(f"{positive_seed_clip=} ")
+    logger.info(f"{positive_flood_clip=} ")
+    logger.info(f"{negative_seed_clip=} ")
+    logger.info(f"{guard_negative_dilation=}")
 
     if all([item is None for item in (image, background, rms, signal)]):
         raise ValueError("No input maps have been provided. ")
@@ -139,7 +143,7 @@ def reverse_negative_flood_fill(
         input=positive_mask,
         mask=signal > positive_flood_clip,
         iterations=10,
-        structure=np.ones((3, 3)),
+        structure=np.ones((4, 4)),
     )
 
     # Now do the same but on negative islands. The assumption here is that:
@@ -323,17 +327,17 @@ def create_snr_mask_from_fits(
     # as being not masked, and all non-zero values are interpreted as masked. In the
     # case of a fits file, the file may either contain a single frequency or it may
     # contain a cube of images.
-    logger.info(f"Clipping using a {min_snr=}")
     if attempt_reverse_nergative_flood_fill:
         mask_data = reverse_negative_flood_fill(
             signal=np.squeeze(signal_data),
-            positive_seed_clip=5,
+            positive_seed_clip=4,
             positive_flood_clip=2,
-            negative_seed_clip=5,
-            guard_negative_dilation=50,
+            negative_seed_clip=4,
+            guard_negative_dilation=40,
         )
         mask_data = mask_data.reshape(signal_data.shape)
     else:
+        logger.info(f"Clipping using a {min_snr=}")
         mask_data = (signal_data > min_snr).astype(np.int32)
 
     logger.info(f"Writing {mask_names.mask_fits}")

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -4,15 +4,15 @@ thought being towards FITS images.
 
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Tuple, Optional
+from typing import Optional, Tuple
 
 import numpy as np
 from astropy.io import fits
 from astropy.wcs import WCS
 from reproject import reproject_interp
 from scipy.ndimage import (
-    binary_dilation as scipy_binary_dilation,
-)  # Rename to distinguish from skimage
+    binary_dilation as scipy_binary_dilation,  # Rename to distinguish from skimage
+)
 from skimage.filters import butterworth
 from skimage.morphology import binary_erosion
 

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -266,7 +266,7 @@ def process_science_fields(
                 with_butterworth=field_options.use_beam_mask_wbutterworth,
             )
             wsclean_options["auto_mask"] = 1
-            wsclean_options["force_mask_rounds"] = 18
+            wsclean_options["force_mask_rounds"] = 10
             wsclean_options["local_rms"] = False
             wsclean_options["niter"] = 1750000
             wsclean_options["nmiter"] = 20


### PR DESCRIPTION
At times it is desirable to construct a clean mask outside of wsclean. Although wsclean has functionality to create SNR based masks throughout cleaning, it can be hard to come up with a universal set of thresholds. 

I have been toying around with an idea similar to the island finding in source finders. Premise is to seed an initial set of islands at a high threshold, and grow them to lower flux density levels through a binary dilation process. It seems to work fairly well, especially when picking up the fainter diffuse structure that sounds doubles / hotspots etc. This seems to help ensure that we do not set too low a cleaning threshold during the wsclean peak finding. 

Without the clean mask from a reverse flood fill

![Screen Shot 2024-04-04 at 12 11 33](https://github.com/tjgalvin/flint/assets/10543142/6a3e9ecb-4f58-4a93-bdb9-e4db6e586116)

and with

![Screen Shot 2024-04-04 at 12 11 47](https://github.com/tjgalvin/flint/assets/10543142/23440633-1fee-4690-86d8-f1c0844216d4)




Also been trying to understand how negative islands / artefacts around bright sources might be exploited to refine the clean mask. Idea is to detect islands a significant negative sigma level, and grow islands from these will guarding bright positive islands e.g. bright compact source causing the negative artefacts. 

![Screen Shot 2024-04-02 at 21 20 33](https://github.com/tjgalvin/flint/assets/10543142/96c67a4c-8587-41d3-ad98-a3835b54aaa5)


  