### PR TITLE
Added a template approach to specify imaging and self-calibration settings

### DIFF
--- a/flint/configuration.py
+++ b/flint/configuration.py
@@ -341,6 +341,25 @@ def load_strategy_yaml(input_yaml: Path, verify: bool = True) -> Strategy:
     return input_strategy
 
 
+def write_strategy_to_yaml(strategy: Strategy, output_path: Path) -> Path:
+    """Write the contents of a current strategy to a yaml file
+
+    Args:
+        strategy (Strategy): The strategy to write out
+        output_path (Path): Where to write the output YAML file to
+
+    Returns:
+        Path: The path the output YAML file was written to
+    """
+
+    logger.info(f"Writing stategy to {output_path=}")
+
+    with open(output_path, "w") as out_file:
+        yaml.dump(data=strategy, stream=out_file, sort_keys=False)
+
+    return output_path
+
+
 def create_default_yaml(
     output_yaml: Path, selfcal_rounds: Optional[int] = None
 ) -> Path:

--- a/flint/configuration.py
+++ b/flint/configuration.py
@@ -190,28 +190,38 @@ def get_options_from_strategy(
         Dict[Any, Any]: Options specific to the requested set
     """
 
+    # Some sanity checks
+    assert isinstance(
+        strategy, (Strategy, dict)
+    ), f"Unknown input strategy type {type(strategy)}"
     assert round == "initial" or isinstance(
         round, int
     ), f"{round=} not a known value or type. "
 
     # step one, get the defaults
-    options = dict(**strategy["defaults"][mode]) if mode in strategy["defaults"] else {}
+    options = (
+        dict(**strategy["defaults"][mode])
+        if mode in strategy["defaults"].keys()
+        else {}
+    )
     logger.debug(f"Defaults for {mode=}, {options=}")
 
     # Now get the updates
-    if round == "initial" and mode in strategy["initial"].keys():
-        update_options = dict(**strategy["initial"][mode])
-        logger.debug(f"Updating options with {update_options=}")
-        options.update(update_options)
-    elif (
-        isinstance(round, int)
-        and round in strategy["selfcal"].keys()
-        and mode in strategy["selfcal"][round].keys()
-    ):
-        update_options = dict(**strategy["selfcal"][round][mode])
-
-        logger.debug(f"Updating options with {update_options=}")
-        options.update(update_options)
+    if round == "initial":
+        # separate function to avoid a missing mode from raising valu error
+        if mode in strategy["initial"].keys():
+            update_options = dict(**strategy["initial"][mode])
+            logger.debug(f"Updating options with {update_options=}")
+            options.update(update_options)
+    elif isinstance(round, int):
+        # separate function to avoid a missing mode from raising valu error
+        if (
+            round in strategy["selfcal"].keys()
+            and mode in strategy["selfcal"][round].keys()
+        ):
+            update_options = dict(**strategy["selfcal"][round][mode])
+            logger.debug(f"Updating options with {update_options=}")
+            options.update(update_options)
     else:
         raise ValueError(f"{round=} not recognised.")
 

--- a/flint/configuration.py
+++ b/flint/configuration.py
@@ -6,7 +6,7 @@ throughout the pipeline.
 
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 import yaml
 
@@ -166,6 +166,16 @@ def get_image_options_from_yaml(
                 "multiscale_scales": MULTISCALE_SCALES,
             },
         }
+
+
+def get_options_from_strategy(
+    strategy: Strategy, mode: str = "wsclean", round: Union[str, int] = "initial"
+) -> Dict[Any, Any]:
+    # step one, get the defaults
+
+    options = strategy[mode]
+
+    return options
 
 
 def verify_configuration(input_config: Strategy, raise_on_error: bool = True) -> bool:
@@ -335,7 +345,8 @@ def cli() -> None:
         load_yaml(input_yaml=args.input_yaml)
     elif args.mode == "verify":
         input_config = load_yaml(input_yaml=args.input_yaml)
-        verify_configuration(input_config=input_config)
+        if verify_configuration(input_config=input_config):
+            logger.info(f"{args.input_yaml} appears valid")
     else:
         logger.error(f"{args.mode=} is not set or not known. Check --help. ")
 

--- a/flint/configuration.py
+++ b/flint/configuration.py
@@ -365,9 +365,9 @@ def get_parser() -> ArgumentParser:
         help="Path to a strategy yaml file to load and inspect. ",
     )
     verify_parser = subparser.add_parser(
-        "verify", help="Create an initail yaml file for editing. "
+        "verify", help="Verify a yaml file is correct, as far as we can tell.  "
     )
-    verify_parser.add_argument("input_yaml", type=Path, help="Path to a sdtrategy file")
+    verify_parser.add_argument("input_yaml", type=Path, help="Path to a strategy file")
 
     return parser
 

--- a/flint/data/tests/test_config.yaml
+++ b/flint/data/tests/test_config.yaml
@@ -15,7 +15,7 @@ defaults:
     niter: 750000
     multiscale: true
     multiscale_scale_bias: 0.75
-    multiscale_scales: 
+    multiscale_scales:
     - 0
     - 15
     - 25
@@ -70,12 +70,12 @@ selfcal:
     gaincal: {}
     masking: {}
   2:
-    wsclean: 
+    wsclean:
       multiscale: false
     gaincal: {}
     masking: {}
   3:
-    wsclean: 
+    wsclean:
       data_column: "TheLastRoundIs3"
     gaincal: {}
     masking: {}

--- a/flint/data/tests/test_config.yaml
+++ b/flint/data/tests/test_config.yaml
@@ -1,0 +1,80 @@
+version: 0.1
+defaults:
+  wsclean:
+    abs_mem: 100
+    local_rms_window: 65
+    size: 10128
+    local_rms: true
+    force_mask_rounds: 10
+    auto_mask: 3.5
+    auto_threshold: 0.5
+    threshold: null
+    channels_out: 4
+    mgain: 0.7
+    nmiter: 15
+    niter: 750000
+    multiscale: true
+    multiscale_scale_bias: 0.75
+    multiscale_scales: 
+    - 0
+    - 15
+    - 25
+    - 50
+    - 75
+    - 100
+    - 250
+    - 400
+    fit_spectral_pol: 2
+    weight: briggs -0.5
+    data_column: CORRECTED_DATA
+    scale: 2.5asec
+    gridder: wgridder
+    nwlayers: null
+    wgridder_accuracy: 0.0001
+    join_channels: true
+    minuv_l: null
+    minuvw_m: null
+    maxw: null
+    no_update_model_required: false
+    no_small_inversion: false
+    name: null
+    beam_fitting_size: 1.25
+    fits_mask: null
+    deconvolution_channels: null
+  gaincal:
+    solint: 60s
+    calmode: p
+    round: 0
+    minsnr: 0.0
+    uvrange: '>200m'
+    selectdata: true
+    gaintype: G
+    nspw: 1
+  masking:
+    base_snr_clip: 4
+    flood_fill: true
+    flood_fill_positive_seed_clip: 4.5
+    flood_fill_positive_flood_clip: 1.5
+    suppress_artefacts: true
+    suppress_artefacts_negative_seed_clip: 5
+    suppress_artefacts_guard_negative_dilation: 40
+    grow_low_snr_islands: true
+    grow_low_snr_clip: 1.75
+    grow_low_snr_island_size: 768
+initial:
+  wsclean: {}
+selfcal:
+  1:
+    wsclean:
+      data_column: "EXAMPLE"
+    gaincal: {}
+    masking: {}
+  2:
+    wsclean: 
+      multiscale: false
+    gaincal: {}
+    masking: {}
+  3:
+    wsclean: {}
+    gaincal: {}
+    masking: {}

--- a/flint/data/tests/test_config.yaml
+++ b/flint/data/tests/test_config.yaml
@@ -75,6 +75,7 @@ selfcal:
     gaincal: {}
     masking: {}
   3:
-    wsclean: {}
+    wsclean: 
+      data_column: "TheLastRoundIs3"
     gaincal: {}
     masking: {}

--- a/flint/options.py
+++ b/flint/options.py
@@ -96,3 +96,5 @@ class FieldOptions(NamedTuple):
     """Construct beam masks from MFS images to use for the next round of imaging. """
     use_beam_masks_from: int = 2
     """If `use_beam_masks` is True, start using them from this round of self-calibration"""
+    imaging_strategy: Optional[Path] = None
+    """Path to a FLINT imaging yaml file that contains settings to use throughout imaging"""

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -75,7 +75,11 @@ def process_science_fields(
         len(science_mss) == field_options.expected_ms
     ), f"Expected to find {field_options.expected_ms} in {str(science_path)}, found {len(science_mss)}."
 
-    strategy = load_yaml(input_yaml=field_options.imaging_strategy, verify=True)
+    strategy = (
+        load_yaml(input_yaml=field_options.imaging_strategy, verify=True)
+        if field_options.imaging_strategy
+        else None
+    )
 
     science_folder_name = science_path.name
 

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -12,10 +12,7 @@ from typing import Union
 from prefect import flow, unmapped
 
 from flint.calibrate.aocalibrate import find_existing_solutions
-from flint.configuration import (
-    get_options_from_strategy,
-    load_strategy_yaml,
-)
+from flint.configuration import get_options_from_strategy, load_strategy_yaml
 from flint.logging import logger
 from flint.ms import MS
 from flint.naming import get_sbid_from_path

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -14,7 +14,7 @@ from prefect import flow, unmapped
 from flint.calibrate.aocalibrate import find_existing_solutions
 from flint.configuration import (
     get_options_from_strategy,
-    load_yaml,
+    load_strategy_yaml,
 )
 from flint.logging import logger
 from flint.ms import MS
@@ -76,7 +76,7 @@ def process_science_fields(
     ), f"Expected to find {field_options.expected_ms} in {str(science_path)}, found {len(science_mss)}."
 
     strategy = (
-        load_yaml(input_yaml=field_options.imaging_strategy, verify=True)
+        load_strategy_yaml(input_yaml=field_options.imaging_strategy, verify=True)
         if field_options.imaging_strategy
         else None
     )

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -238,10 +238,10 @@ def process_science_fields(
         final_round = round == field_options.rounds
 
         gain_cal_options = get_options_from_strategy(
-            strategy=strategy, mode="gaincal", round=round
+            strategy=strategy, mode="gaincal", round=current_round
         )
         wsclean_options = get_options_from_strategy(
-            strategy=strategy, mode="wsclean", round=round
+            strategy=strategy, mode="wsclean", round=current_round
         )
 
         cal_mss = task_gaincal_applycal_ms.map(

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -76,6 +76,14 @@ def test_verify(tmpdir):
         verify_configuration(input_config=strat)
 
 
+def test_load_yaml_none():
+    # make sure an error is raise if None is passed in. This
+    # should be checked as the default value of FieldOptions.imaging_strategy
+    # is None.
+    with pytest.raises(TypeError):
+        _ = load_yaml(input_yaml=None)
+
+
 def test_get_options(strategy):
     # test to make sure we can generate a default strategy (see pytest fixture)
     # read it backinto a dict and then access some attributes

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -9,6 +9,7 @@ from flint.configuration import (
     load_strategy_yaml,
     verify_configuration,
     get_options_from_strategy,
+    write_strategy_to_yaml,
     Strategy,
 )
 from flint.utils import get_packaged_resource_path
@@ -244,3 +245,29 @@ def test_raise_error_options_error():
 
     with pytest.raises(AssertionError):
         get_selfcal_options_from_yaml(input_yaml=example)
+
+
+def test_write_strategy_to_yaml(package_strategy, tmpdir):
+    strategy = package_strategy
+
+    output_strategy = Path(tmpdir) / "testing.yaml"
+    write_strategy_to_yaml(strategy=strategy, output_path=output_strategy)
+
+    loaded_strategy = load_strategy_yaml(input_yaml=output_strategy)
+
+    assert len(set(loaded_strategy.keys()) - set(strategy.keys())) == 0
+    assert (
+        len(set(loaded_strategy["initial"].keys()) - set(strategy["initial"].keys()))
+        == 0
+    )
+    assert (
+        len(
+            set(loaded_strategy["selfcal"][1].keys())
+            - set(strategy["selfcal"][1].keys())
+        )
+        == 0
+    )
+    assert (
+        loaded_strategy["selfcal"][1]["wsclean"]["data_column"]
+        == strategy["selfcal"][1]["wsclean"]["data_column"]
+    )

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -3,14 +3,14 @@ from pathlib import Path
 import pytest
 
 from flint.configuration import (
-    get_image_options_from_yaml,
-    get_selfcal_options_from_yaml,
+    Strategy,
     create_default_yaml,
+    get_image_options_from_yaml,
+    get_options_from_strategy,
+    get_selfcal_options_from_yaml,
     load_strategy_yaml,
     verify_configuration,
-    get_options_from_strategy,
     write_strategy_to_yaml,
-    Strategy,
 )
 from flint.utils import get_packaged_resource_path
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -88,6 +88,33 @@ def test_get_options(strategy):
     assert wsclean["data_column"] == "CORRECTED_DATA"
 
 
+def test_get_modes(package_strategy):
+
+    strategy = package_strategy
+
+    for mode in ("wsclean", "gaincal", "masking"):
+        test = get_options_from_strategy(strategy=strategy, mode=mode, round=1)
+        assert isinstance(test, dict)
+        assert len(test.keys()) > 0
+
+
+def test_bad_round(package_strategy):
+    with pytest.raises(AssertionError):
+        _ = get_options_from_strategy(strategy=package_strategy, round="doesnotexists")
+
+    with pytest.raises(AssertionError):
+        _ = get_options_from_strategy(strategy=package_strategy, round=1.23456)
+
+
+def test_empty_options(package_strategy):
+    items = get_options_from_strategy(
+        strategy=package_strategy, mode="thisdoesnotexist"
+    )
+
+    assert isinstance(items, dict)
+    assert len(items.keys()) == 0
+
+
 def test_updated_get_options(package_strategy):
 
     strategy = package_strategy

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -59,6 +59,8 @@ def test_create_and_load(tmpdir):
 
 
 def test_verify(tmpdir):
+    # test to make sure we can generate a default strategy (see pytest fixture)
+    # read it backinto a dict and verify it is valid
     output = create_default_yaml(
         output_yaml=Path(tmpdir) / "example.yaml", selfcal_rounds=3
     )
@@ -75,6 +77,8 @@ def test_verify(tmpdir):
 
 
 def test_get_options(strategy):
+    # test to make sure we can generate a default strategy (see pytest fixture)
+    # read it backinto a dict and then access some attributes
     wsclean = get_options_from_strategy(
         strategy=strategy, mode="wsclean", round="initial"
     )
@@ -106,6 +110,24 @@ def test_bad_round(package_strategy):
 
     with pytest.raises(AssertionError):
         _ = get_options_from_strategy(strategy=package_strategy, round=1.23456)
+
+
+def test_empty_strategy_empty_options():
+    # if None is given as a strategy state then empty set of options is return
+    res = get_options_from_strategy(strategy=None)
+
+    assert isinstance(res, dict)
+    assert not res == 0
+
+
+def test_max_round_override(package_strategy):
+    # ebsyre that the logic to switch to the highest available slefcal
+    # round is sound
+    strategy = package_strategy
+
+    opts = get_options_from_strategy(strategy=strategy, round=9999)
+    assert isinstance(opts, dict)
+    assert opts["data_column"] == "TheLastRoundIs3"
 
 
 def test_empty_options(package_strategy):

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -5,7 +5,49 @@ import pytest
 from flint.configuration import (
     get_image_options_from_yaml,
     get_selfcal_options_from_yaml,
+    create_default_yaml,
+    load_yaml,
+    verify_configuration,
+    Strategy,
 )
+
+
+def test_create_yaml_file(tmpdir):
+    output = create_default_yaml(
+        output_yaml=Path(tmpdir) / "example.yaml", selfcal_rounds=3
+    )
+
+    assert output.exists()
+
+
+def test_create_and_load(tmpdir):
+    output = create_default_yaml(
+        output_yaml=Path(tmpdir) / "example.yaml", selfcal_rounds=3
+    )
+
+    assert output.exists()
+
+    strat = load_yaml(input_yaml=output)
+    assert isinstance(strat, Strategy)
+
+    strat = load_yaml(input_yaml=output, verify=False)
+    assert isinstance(strat, Strategy)
+
+
+def test_verify(tmpdir):
+    output = create_default_yaml(
+        output_yaml=Path(tmpdir) / "example.yaml", selfcal_rounds=3
+    )
+
+    assert output.exists()
+    strat = load_yaml(input_yaml=output, verify=False)
+    assert isinstance(strat, Strategy)
+
+    _ = verify_configuration(input_config=strat)
+
+    strat["ddd"] = 123
+    with pytest.raises(ValueError):
+        verify_configuration(input_config=strat)
 
 
 def test_get_image_options():

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -89,7 +89,8 @@ def test_get_options(strategy):
 
 
 def test_get_modes(package_strategy):
-
+    # makes sure defaults for these modes are return when reuestion options
+    # on a self-cal round without them set
     strategy = package_strategy
 
     for mode in ("wsclean", "gaincal", "masking"):
@@ -99,6 +100,7 @@ def test_get_modes(package_strategy):
 
 
 def test_bad_round(package_strategy):
+    # make sure incorrect round is handled properly
     with pytest.raises(AssertionError):
         _ = get_options_from_strategy(strategy=package_strategy, round="doesnotexists")
 
@@ -107,12 +109,19 @@ def test_bad_round(package_strategy):
 
 
 def test_empty_options(package_strategy):
+    # ensures an empty options dict is return should something not set is requested
     items = get_options_from_strategy(
         strategy=package_strategy, mode="thisdoesnotexist"
     )
 
     assert isinstance(items, dict)
     assert len(items.keys()) == 0
+
+
+def test_assert_strategy_bad():
+    # tests to see if a error is raised when a bad strategy instance is passed in
+    with pytest.raises(AssertionError):
+        _ = get_options_from_strategy(strategy="ThisIsBad")
 
 
 def test_updated_get_options(package_strategy):


### PR DESCRIPTION
To-date imaging (e.g. wsclean), self-calibration (e.g. gaincal) and other things have been hard-coded into the `flint` codebase. When updating these throughout the rounds of self-calibration a dictionary with updated values would be obtained and splatted into the creation of the appropriate `Options`. 

This is pretty tiresome. If the `git` history is examined it would be pretty obvious how many times commits were made purely to change the image size, solution interval, or something trivial. 

This pull request introduces a template yaml file that is used to set the options that may or may not evolve as the pipeline runs. The idea is that a file (at the moment a yaml file) is parsed into a `Strategy` class, which is nothing more than a glorified name for a dictionary (but nice for type checking). Throughout the pipeline the `Strategy` with be investigated to:
- get defaults for an `Option` mode
- check for and updated values for the specific round of imaging
- update the defaults
- return the updated defaults

The existing infrastructure to overload the hardcoded defaults of an `Option` type class is used as normal. 