### PR TITLE
Add Configargparse to main continuum pipeline

### DIFF
--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -474,7 +474,6 @@ def get_parser() -> ArgumentParser:
     parser.add_argument(
         "--linmos-residuals",
         action="store_true",
-        default=False,
         help="Co-add the per-beam cleaning residuals into a field image",
     )
     parser.add_argument(

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -5,7 +5,7 @@
 - run aegean source finding
 """
 
-from argparse import ArgumentParser
+from configargparse import ArgumentParser
 from pathlib import Path
 from typing import Union
 

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -5,10 +5,10 @@
 - run aegean source finding
 """
 
-from configargparse import ArgumentParser
 from pathlib import Path
 from typing import Union
 
+from configargparse import ArgumentParser
 from prefect import flow, unmapped
 
 from flint.calibrate.aocalibrate import find_existing_solutions

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -369,6 +369,10 @@ def get_parser() -> ArgumentParser:
     parser = ArgumentParser(description=__doc__)
 
     parser.add_argument(
+        "--cli-config", is_config_file=True, help="Path to configuration file"
+    )
+
+    parser.add_argument(
         "science_path",
         type=Path,
         help="Path to directories containing the beam-wise science measurementsets that will have solutions copied over and applied.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ radio-beam = "^0.3.4"
 reproject = "*"
 scikit-image = "*"
 pandas = "*"
+ConfigArgParse = "^1.7"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.3.0"

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -9,6 +9,61 @@ from flint.options import FieldOptions
 from flint.prefect.flows.continuum_pipeline import get_parser
 
 
+def test_config_field_options(tmpdir):
+    output_file = f"{tmpdir}/example.config"
+    contents = """--holofile /scratch3/projects/spiceracs/RACS_Low2_Holography/akpb.iquv.square_6x6.63.887MHz.SB39549.cube.fits
+        --calibrate-container /scratch3/gal16b/containers/calibrate.sif
+        --flagger-container /scratch3/gal16b/containers/aoflagger.sif
+        --wsclean-container /scratch3/projects/spiceracs/singularity_images/wsclean_force_mask.sif
+        --yandasoft-container /scratch3/gal16b/containers/yandasoft.sif
+        --cluster-config /scratch3/gal16b/split/petrichor.yaml
+        --selfcal-rounds 2
+        --split-path $(pwd)
+        --zip-ms
+        --run-aegean
+        --aegean-container '/scratch3/gal16b/containers/aegean.sif'
+        --reference-catalogue-directory '/scratch3/gal16b/reference_catalogues/'
+        --linmos-residuals
+    """
+
+    with open(output_file, "w") as out:
+        for line in contents.split("\n"):
+            out.write(f"{line.lstrip()}\n")
+
+    parser = get_parser()
+    args = parser.parse_args(
+        f"""/scratch3/gal16b/askap_sbids/112334/
+        /scratch3/gal16b/askap_sbids/111/
+        --cli-config {str(output_file)}""".split()
+    )
+
+    field_options = FieldOptions(
+        flagger_container=args.flagger_container,
+        calibrate_container=args.calibrate_container,
+        holofile=args.holofile,
+        expected_ms=args.expected_ms,
+        wsclean_container=args.wsclean_container,
+        yandasoft_container=args.yandasoft_container,
+        rounds=args.selfcal_rounds,
+        zip_ms=args.zip_ms,
+        run_aegean=args.run_aegean,
+        aegean_container=args.aegean_container,
+        no_imaging=args.no_imaging,
+        reference_catalogue_directory=args.reference_catalogue_directory,
+        linmos_residuals=args.linmos_residuals,
+        beam_cutoff=args.beam_cutoff,
+        pb_cutoff=args.pb_cutoff,
+        use_preflagger=args.use_preflagger,
+    )
+
+    assert isinstance(field_options, FieldOptions)
+    assert field_options.use_preflagger is False
+    assert field_options.zip_ms is True
+    assert field_options.linmos_residuals is True
+    assert field_options.rounds == 2
+    assert isinstance(field_options.wsclean_container, Path)
+
+
 def test_create_field_options():
     parser = get_parser()
     args = parser.parse_args(


### PR DESCRIPTION
It is nice to have a way of providing a configuration file to list the optional CLI arguments for the main continuum imaging and self-calibration pipeline. 

I have added `configargparse` as a dependency in order to allow a user to either:
- specify optional CLI arguments normally
- set a configuration file that outlines all optional arguments
- set a configuration file for optional arguments which may be obverloaded on the CLI

It is a drop in replacement for the normal `argparse.ArgumentParser` and seems to be working nicely. A primitive unit test has also been added.  