### PR TITLE
added callback function

### DIFF
--- a/flint/exceptions.py
+++ b/flint/exceptions.py
@@ -14,3 +14,9 @@ class GainCalError(Exception):
     """Raised when it appears like the casa gaincal task fails."""
 
     pass
+
+
+class CleanDivergenceError(Exception):
+    """Raised if it is detected that cleaning has diverged."""
+
+    pass

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -143,7 +143,9 @@ class WSCleanCommand(NamedTuple):
 def _wsclean_output_callback(line: str) -> None:
     """Call back function used to detect clean divergence"""
 
-    if "KJy" in line:
+    assert isinstance(line, str)
+
+    if "Iteration" in line and "KJy" in line:
         raise CleanDivergenceError(f"Clean divergence detected: {line}")
 
 

--- a/flint/sclient.py
+++ b/flint/sclient.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from socket import gethostname
 from subprocess import CalledProcessError
-from typing import Collection, Optional, Union
+from typing import Collection, Optional, Union, Callable
 
 from spython.main import Client as sclient
 
@@ -11,7 +11,10 @@ from flint.logging import logger
 
 
 def run_singularity_command(
-    image: Path, command: str, bind_dirs: Optional[Union[Path, Collection[Path]]] = None
+    image: Path,
+    command: str,
+    bind_dirs: Optional[Union[Path, Collection[Path]]] = None,
+    stream_callback_func: Optional[Callable] = None,
 ) -> None:
     """Executes a command within the context of a nominated singularity
     container
@@ -20,6 +23,7 @@ def run_singularity_command(
         image (Path): The singularity container image to use
         command (str): The command to execute
         bind_dirs (Optional[Union[Path,Collection[Path]]], optional): Specifies a Path, or list of Paths, to bind to in the container. Defaults to None.
+        stream_callback_func (Optional[Callable], optional): Provide a function that is applied to each line of output text when singularity is running and `stream=True`. IF provide it should accept a single (string) parameter. If None, nothing happens. Defaultds to None.
 
     Raises:
         FileNotFoundError: Thrown when container image not found
@@ -60,6 +64,8 @@ def run_singularity_command(
 
         for line in output:
             logger.info(line.rstrip())
+            if stream_callback_func:
+                stream_callback_func(line)
     except CalledProcessError as e:
         logger.error(f"Failed to run command: {command}")
         logger.error(f"Stdout: {e.stdout}")

--- a/tests/test_wsclean.py
+++ b/tests/test_wsclean.py
@@ -4,7 +4,30 @@ from pathlib import Path
 
 import pytest
 
-from flint.imager.wsclean import ImageSet, get_wsclean_output_names
+from flint.exceptions import CleanDivergenceError
+from flint.imager.wsclean import (
+    ImageSet,
+    get_wsclean_output_names,
+    _wsclean_output_callback,
+)
+
+
+def test_wsclean_divergence():
+    good = (
+        "Iteration 59228, scale 0 px : -862.94 µJy at 3729,3746",
+        "Opening reordered part 0 spw 0 for /scratch3/gal16b/flint_peel/40470/SB40470.RACS_1237+00.beam4.round1.ms",
+        "Opening reordered part 0 spw 0 for /scratch3/gal16b/flint_peel/40470/SB40470.RACS_1237+00.beam4.round1.ms",
+        "Although KJy there is no iterat ion, not the lack of a capital-I and the space, clever pirate",
+    )
+    for g in good:
+        _wsclean_output_callback(line=g)
+
+    bad = "Iteration 59228, scale 0 px : -862.94 KJy at 3729,3746"
+    with pytest.raises(CleanDivergenceError):
+        _wsclean_output_callback(line=bad)
+
+    with pytest.raises(AssertionError):
+        _wsclean_output_callback(line=tuple("A tuple of text".split()))
 
 
 def test_wsclean_output_named_raises():

--- a/tests/test_wsclean.py
+++ b/tests/test_wsclean.py
@@ -13,6 +13,7 @@ from flint.imager.wsclean import (
 
 
 def test_wsclean_divergence():
+    """Make sure the wsclean call back function picks up divergence and raises appropriate errors"""
     good = (
         "Iteration 59228, scale 0 px : -862.94 µJy at 3729,3746",
         "Opening reordered part 0 spw 0 for /scratch3/gal16b/flint_peel/40470/SB40470.RACS_1237+00.beam4.round1.ms",


### PR DESCRIPTION
It is sometimes useful to verify the output of a singularity command as it is running, eg. in wsclean. 

Added an ability to provide a callback function that is evaluated against each line of output logs generated from a sclient run call. 

Addresses #88 