### PR TITLE
Rotate holography beams when linmos'ing

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ Most of the `python` routines have a CLI that can be used to test them in a piec
 - `flint_aegean`: Simple interface to execute BANE and aegean against a provided image. These tools are expected to be packaged in a singularity container.
 - `flint_validation_plot`: Create a simple, quick look figure that expresses the key quality statistics of an image. It is intended to be used against a full continuum field image, but in-principal be used for a per beam image.
 - `flint_potato`: Attempt to peel out known sources from a measurement set using [potatopeel](
-https://gitlab.com/Sunmish/potato/-/tree/main). Criteria used to assess which sources to peel is fairly minimumal, and at the time of writing only the reference set of sources paackaged within `flint` are considered. 
+https://gitlab.com/Sunmish/potato/-/tree/main). Criteria used to assess which sources to peel is fairly minimumal, and at the time of writing only the reference set of sources paackaged within `flint` are considered.
 
 The following commands use the `prefect` framework to link together individual tasks together (outlined above) into a single data-processing pipeline.
 - `flint_flow_bandpass_calibrate`: Executes a prefect flow run that will calibrate a set of ASKAP measurement sets taken during a normal bandpass observation sequence.
 - `flint_flow_continuum_pipeline`: Performs bandpass calibration, solution copying, imaging, self-calibration and mosaicing.
-- `flint_flow_cointinuum_mask_pipeline`: Performs bandpass calibration, solution copying, imaging, self-calibration and mosaicing. In this flow a process to construct a robust clean mask is performed by exploiting an initial imaging round. The field image is constructed across all beams, S/N clipping is performed, then guard masks on a per-beam basis are extracted. This pipeline has fallen out of use and could be removed. 
+- `flint_flow_cointinuum_mask_pipeline`: Performs bandpass calibration, solution copying, imaging, self-calibration and mosaicing. In this flow a process to construct a robust clean mask is performed by exploiting an initial imaging round. The field image is constructed across all beams, S/N clipping is performed, then guard masks on a per-beam basis are extracted. This pipeline has fallen out of use and could be removed.
 
 ## Sky-model catalogues
 
@@ -56,26 +56,26 @@ https://gitlab.com/Sunmish/potato/-/tree/main)
 
 ## Configuration based settings
 
-Most settings within `flint` are stored in immutable option classes, e.g. `WSCleanOptions`, `GainCalOptions`. Once they such an option class has been created, any new option values may only be set by creating a new instance. In such cases there is an appropriate `.with_options` method that might be of use. This 'nothing changes unless explicitly done so' was adopted early as a way to avoid confusing when moving to a distributed multi-node execution environment. 
+Most settings within `flint` are stored in immutable option classes, e.g. `WSCleanOptions`, `GainCalOptions`. Once they such an option class has been created, any new option values may only be set by creating a new instance. In such cases there is an appropriate `.with_options` method that might be of use. This 'nothing changes unless explicitly done so' was adopted early as a way to avoid confusing when moving to a distributed multi-node execution environment.
 
-The added benefit is that it has defined very clear interfaces into key stages throughout `flint`s calibration and imaging stages. The `flint_config` program can be used to create template `yaml` file that lists default values of these option classes that are expected to be user-tweakable, and provides the ability to change values of options throughout initial imaging and subsequent rounds of self-calibration. 
+The added benefit is that it has defined very clear interfaces into key stages throughout `flint`s calibration and imaging stages. The `flint_config` program can be used to create template `yaml` file that lists default values of these option classes that are expected to be user-tweakable, and provides the ability to change values of options throughout initial imaging and subsequent rounds of self-calibration.
 
 In a nutshell, the three *currently* supported option classes that may be tweaked through this template method are:
 - `WSCleanOptions` (shorthand `wsclean`)
 - `GainCalOptions` (shorthand `gaincal`)
 - `MaskingOptions` (shorthand `masking`)
 
-All attributed supported by these options may be set in this template format. 
+All attributed supported by these options may be set in this template format.
 
-The `defaults` scope sets all of the default values of these classes. The `initial` scope overrides the default imaging `wsclean` options to be used with the first round of imaging *before self-calibration*. 
+The `defaults` scope sets all of the default values of these classes. The `initial` scope overrides the default imaging `wsclean` options to be used with the first round of imaging *before self-calibration*.
 
 The `selfcal` scope contains a key-value mapping, where an `integer` key relates the options to that specific round of masking, imaging and calibration options for that round of self-calibration. Again, options set here override the corresponding options defined in the `defaults` scope.
 
-`flint_config` can be used to generate a template file, which can then be tweaked. The template file uses YAML to define scope and settings. So, use the YAML standard when modifying this file. There are primative verification functions to ensure the modified template file is correctly form. 
+`flint_config` can be used to generate a template file, which can then be tweaked. The template file uses YAML to define scope and settings. So, use the YAML standard when modifying this file. There are primative verification functions to ensure the modified template file is correctly form.
 
 ## CLI Configuration file
 
-To help manage (and avoid) long CLI calls to conffigure `flint`, most command line options may be dumped into a new-line delimited text file which can then be set as the `--cli-config` option of some workflows. See the `configargparse` python utility to read up on more on how options may be overridden if speficied in both the text file and CLI call. 
+To help manage (and avoid) long CLI calls to conffigure `flint`, most command line options may be dumped into a new-line delimited text file which can then be set as the `--cli-config` option of some workflows. See the `configargparse` python utility to read up on more on how options may be overridden if speficied in both the text file and CLI call.
 
 ## Validation Plots
 

--- a/flint/coadd/linmos.py
+++ b/flint/coadd/linmos.py
@@ -13,7 +13,7 @@ from flint.sclient import run_singularity_command
 
 # This is the expected orientation of the third-axis and footprint (remember the footprint
 # can be electronically rotated).
-EXPECTED_HOLOGRAPHY_ROTATION_CONSTANT_RADIANS = -np.pi / 8
+EXPECTED_HOLOGRAPHY_ROTATION_CONSTANT_RADIANS = -2 * np.pi / 8
 
 
 class LinmosCommand(NamedTuple):

--- a/flint/coadd/linmos.py
+++ b/flint/coadd/linmos.py
@@ -248,8 +248,8 @@ def generate_linmos_parameter_set(
     logger.info(f"{len(img_str)} unique images from {len(images)} input collection. ")
     img_list: str = "[" + ",".join(img_str) + "]"
 
-    assert (
-        len(set(img_str)) == len(images)
+    assert len(set(img_str)) == len(
+        images
     ), "Some images were dropped from the linmos image string. Something is bad, walk the plank. "
 
     # If no weights_list has been provided (and therefore no optimal
@@ -274,7 +274,7 @@ def generate_linmos_parameter_set(
     alpha = None
     if pol_axis:
         logger.info(
-            f"The constant assumed holography pol_axis + footprint rotation is: {EXPECTED_HOLOGRAPHY_ROTATION_CONSTANT_RADIANS:.4f} radians"
+            f"The constant assumed holography rotation is: {EXPECTED_HOLOGRAPHY_ROTATION_CONSTANT_RADIANS:.4f} radians"
         )
         logger.info(f"The extracted pol_axis of the field: {pol_axis:.4f} radians")
         alpha = pol_axis - EXPECTED_HOLOGRAPHY_ROTATION_CONSTANT_RADIANS

--- a/flint/coadd/linmos.py
+++ b/flint/coadd/linmos.py
@@ -248,8 +248,8 @@ def generate_linmos_parameter_set(
     logger.info(f"{len(img_str)} unique images from {len(images)} input collection. ")
     img_list: str = "[" + ",".join(img_str) + "]"
 
-    assert len(set(img_str)) == len(
-        images
+    assert (
+        len(set(img_str)) == len(images)
     ), "Some images were dropped from the linmos image string. Something is bad, walk the plank. "
 
     # If no weights_list has been provided (and therefore no optimal

--- a/flint/coadd/linmos.py
+++ b/flint/coadd/linmos.py
@@ -273,6 +273,10 @@ def generate_linmos_parameter_set(
     # unknown to us (not stored in the cube header).
     alpha = None
     if pol_axis:
+        logger.info(
+            f"The constant assumed holography pol_axis + footprint rotation is: {EXPECTED_HOLOGRAPHY_ROTATION_CONSTANT_RADIANS:.4f} radians"
+        )
+        logger.info(f"The extracted pol_axis of the field: {pol_axis:.4f} radians")
         alpha = pol_axis - EXPECTED_HOLOGRAPHY_ROTATION_CONSTANT_RADIANS
         logger.info(f"Differential rotation is: {alpha} rad")
 

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -397,6 +397,7 @@ def task_linmos_images(
     sbid: Optional[int] = None,
     parset_output_path: Optional[str] = None,
     cutoff: float = 0.05,
+    field_summary: Optional[FieldSummary] = None,
 ) -> LinmosCommand:
     """Run the yandasoft linmos task against a set of input images
 
@@ -410,6 +411,7 @@ def task_linmos_images(
         sbid (Optional[int], optional): SBID of the data being imaged. Defaults to None.
         parset_output_path (Optional[str], optional): Location to write the linmos parset file to. Defaults to None.
         cutoff (float, optional): The primary beam attenuation cutoff supplied to linmos when coadding. Defaults to 0.05.
+        field_summary (Optional[FieldSummary], optional): The summary of the field, including (importantly) to orientation of the third-axis. Defaults to None.
 
     Returns:
         LinmosCommand: The linmos command and associated meta-data
@@ -446,6 +448,8 @@ def task_linmos_images(
     parset_output_path = out_dir / Path(parset_output_path)
     logger.info(f"Parsert output path is {parset_output_path}")
 
+    pol_axis = field_summary.pol_axis if field_summary else None
+
     linmos_cmd = linmos_images(
         images=filter_images,
         parset_output_path=Path(parset_output_path),
@@ -453,6 +457,7 @@ def task_linmos_images(
         container=container,
         holofile=holofile,
         cutoff=cutoff,
+        pol_axis=pol_axis,
     )
 
     return linmos_cmd
@@ -464,6 +469,7 @@ def _convolve_linmos_residuals(
     field_options: FieldOptions,
     linmos_suffix_str: str,
     cutoff: float = 0.05,
+    field_summary: Optional[FieldSummary] = None,
 ) -> LinmosCommand:
     """An internal function that launches the convolution to a common resolution
     and subsequent linmos of the wsclean residual images.
@@ -474,6 +480,7 @@ def _convolve_linmos_residuals(
         field_options (FieldOptions): Options related to the processing of the field
         linmos_suffix_str (str): The suffix string passed to the linmos parset name
         cutoff (float, optional): The primary beam attenuation cutoff supplied to linmos when coadding. Defaults to 0.05.
+        field_summary (Optional[FieldSummary], optional): The summary of the field, including (importantly) to orientation of the third-axis. Defaults to None.
 
     Returns:
         LinmosCommand: Resulting linmos command parset
@@ -491,6 +498,7 @@ def _convolve_linmos_residuals(
         suffix_str=linmos_suffix_str,
         holofile=field_options.holofile,
         cutoff=cutoff,
+        field_summary=field_summary,
     )
 
     return parset

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -215,6 +215,7 @@ def process_science_fields(
             suffix_str="noselfcal",
             holofile=field_options.holofile,
             cutoff=field_options.pb_cutoff,
+            field_summary=field_summary,
         )
 
         if run_aegean:
@@ -241,6 +242,7 @@ def process_science_fields(
                 field_options=field_options,
                 linmos_suffix_str="residual.noselfcal",
                 cutoff=field_options.pb_cutoff,
+                field_summary=field_summary,
             )
 
     if field_options.rounds is None:

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -317,6 +317,7 @@ def process_science_fields(
             suffix_str=f"round{current_round}",
             holofile=field_options.holofile,
             cutoff=field_options.pb_cutoff,
+            field_summary=field_summary,
         )
 
         if field_options.linmos_residuals:
@@ -326,6 +327,7 @@ def process_science_fields(
                 field_options=field_options,
                 linmos_suffix_str=f"round{current_round}.residual",
                 cutoff=field_options.pb_cutoff,
+                field_summary=field_summary,
             )
 
         if final_round and run_aegean:

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Union
 
 from configargparse import ArgumentParser
-from prefect import flow, unmapped, tags
+from prefect import flow, tags, unmapped
 
 from flint.calibrate.aocalibrate import find_existing_solutions
 from flint.configuration import (

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -251,7 +251,7 @@ def process_science_fields(
     fits_beam_masks = None
 
     for current_round in range(1, field_options.rounds + 1):
-        with tags(f"selfcal-{round}"):
+        with tags(f"selfcal-{current_round}"):
             final_round = round == field_options.rounds
 
             gain_cal_options = get_options_from_strategy(

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -254,7 +254,7 @@ def process_science_fields(
 
     for current_round in range(1, field_options.rounds + 1):
         with tags(f"selfcal-{current_round}"):
-            final_round = round == field_options.rounds
+            final_round = current_round == field_options.rounds
 
             gain_cal_options = get_options_from_strategy(
                 strategy=strategy, mode="gaincal", round=current_round

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Union
 
 from configargparse import ArgumentParser
-from prefect import flow, unmapped
+from prefect import flow, unmapped, tags
 
 from flint.calibrate.aocalibrate import find_existing_solutions
 from flint.configuration import (
@@ -251,100 +251,104 @@ def process_science_fields(
     fits_beam_masks = None
 
     for current_round in range(1, field_options.rounds + 1):
-        final_round = round == field_options.rounds
+        with tags(f"selfcal-{round}"):
+            final_round = round == field_options.rounds
 
-        gain_cal_options = get_options_from_strategy(
-            strategy=strategy, mode="gaincal", round=current_round
-        )
-        wsclean_options = get_options_from_strategy(
-            strategy=strategy, mode="wsclean", round=current_round
-        )
-
-        cal_mss = task_gaincal_applycal_ms.map(
-            wsclean_cmd=wsclean_cmds,
-            round=current_round,
-            update_gain_cal_options=unmapped(gain_cal_options),
-            archive_input_ms=field_options.zip_ms,
-            wait_for=[
-                field_summary
-            ],  # To make sure field summary is created with unzipped MSs
-        )
-
-        if (
-            field_options.use_beam_masks
-            and current_round >= field_options.use_beam_masks_from
-        ):
-            beam_aegean_outputs = task_run_bane_and_aegean.map(
-                image=wsclean_cmds,
-                aegean_container=unmapped(field_options.aegean_container),
+            gain_cal_options = get_options_from_strategy(
+                strategy=strategy, mode="gaincal", round=current_round
             )
-            fits_beam_masks = task_create_image_mask_model.map(
-                image=wsclean_cmds,
-                image_products=beam_aegean_outputs,
-                min_snr=3.5,
+            wsclean_options = get_options_from_strategy(
+                strategy=strategy, mode="wsclean", round=current_round
             )
 
-        wsclean_cmds = task_wsclean_imager.map(
-            in_ms=cal_mss,
-            wsclean_container=field_options.wsclean_container,
-            update_wsclean_options=unmapped(wsclean_options),
-            fits_mask=fits_beam_masks,
-        )
-
-        # Do source finding on the last round of self-cal'ed images
-        if round == field_options.rounds and run_aegean:
-            task_run_bane_and_aegean.map(
-                image=wsclean_cmds,
-                aegean_container=unmapped(field_options.aegean_container),
+            cal_mss = task_gaincal_applycal_ms.map(
+                wsclean_cmd=wsclean_cmds,
+                round=current_round,
+                update_gain_cal_options=unmapped(gain_cal_options),
+                archive_input_ms=field_options.zip_ms,
+                wait_for=[
+                    field_summary
+                ],  # To make sure field summary is created with unzipped MSs
             )
 
-        beam_shape = task_get_common_beam.submit(
-            wsclean_cmds=wsclean_cmds, cutoff=field_options.beam_cutoff, filter="-MFS-"
-        )
-        conv_images = task_convolve_image.map(
-            wsclean_cmd=wsclean_cmds,
-            beam_shape=unmapped(beam_shape),
-            cutoff=field_options.beam_cutoff,
-            filter="-MFS-",
-        )
-        if field_options.yandasoft_container is None:
-            logger.info("No yandasoft container supplied, not linmosing. ")
-            continue
+            if (
+                field_options.use_beam_masks
+                and current_round >= field_options.use_beam_masks_from
+            ):
+                beam_aegean_outputs = task_run_bane_and_aegean.map(
+                    image=wsclean_cmds,
+                    aegean_container=unmapped(field_options.aegean_container),
+                )
+                fits_beam_masks = task_create_image_mask_model.map(
+                    image=wsclean_cmds,
+                    image_products=beam_aegean_outputs,
+                    min_snr=3.5,
+                )
 
-        parset = task_linmos_images.submit(
-            images=conv_images,
-            container=field_options.yandasoft_container,
-            suffix_str=f"round{current_round}",
-            holofile=field_options.holofile,
-            cutoff=field_options.pb_cutoff,
-            field_summary=field_summary,
-        )
+            wsclean_cmds = task_wsclean_imager.map(
+                in_ms=cal_mss,
+                wsclean_container=field_options.wsclean_container,
+                update_wsclean_options=unmapped(wsclean_options),
+                fits_mask=fits_beam_masks,
+            )
 
-        if field_options.linmos_residuals:
-            _convolve_linmos_residuals(
+            # Do source finding on the last round of self-cal'ed images
+            if round == field_options.rounds and run_aegean:
+                task_run_bane_and_aegean.map(
+                    image=wsclean_cmds,
+                    aegean_container=unmapped(field_options.aegean_container),
+                )
+
+            beam_shape = task_get_common_beam.submit(
                 wsclean_cmds=wsclean_cmds,
-                beam_shape=beam_shape,
-                field_options=field_options,
-                linmos_suffix_str=f"round{current_round}.residual",
+                cutoff=field_options.beam_cutoff,
+                filter="-MFS-",
+            )
+            conv_images = task_convolve_image.map(
+                wsclean_cmd=wsclean_cmds,
+                beam_shape=unmapped(beam_shape),
+                cutoff=field_options.beam_cutoff,
+                filter="-MFS-",
+            )
+            if field_options.yandasoft_container is None:
+                logger.info("No yandasoft container supplied, not linmosing. ")
+                continue
+
+            parset = task_linmos_images.submit(
+                images=conv_images,
+                container=field_options.yandasoft_container,
+                suffix_str=f"round{current_round}",
+                holofile=field_options.holofile,
                 cutoff=field_options.pb_cutoff,
                 field_summary=field_summary,
             )
 
-        if final_round and run_aegean:
-            aegean_outputs = task_run_bane_and_aegean.submit(
-                image=parset, aegean_container=unmapped(field_options.aegean_container)
-            )
-            linmos_field_summary = task_update_field_summary.submit(
-                field_summary=linmos_field_summary,
-                aegean_outputs=aegean_outputs,
-                round=current_round,
-            )
-            if run_validation:
-                _validation_items(
+            if field_options.linmos_residuals:
+                _convolve_linmos_residuals(
+                    wsclean_cmds=wsclean_cmds,
+                    beam_shape=beam_shape,
+                    field_options=field_options,
+                    linmos_suffix_str=f"round{current_round}.residual",
+                    cutoff=field_options.pb_cutoff,
+                    field_summary=field_summary,
+                )
+
+            if final_round and run_aegean:
+                aegean_outputs = task_run_bane_and_aegean.submit(
+                    image=parset,
+                    aegean_container=unmapped(field_options.aegean_container),
+                )
+                linmos_field_summary = task_update_field_summary.submit(
                     field_summary=linmos_field_summary,
                     aegean_outputs=aegean_outputs,
-                    reference_catalogue_directory=field_options.reference_catalogue_directory,
+                    round=current_round,
                 )
+                if run_validation:
+                    _validation_items(
+                        field_summary=linmos_field_summary,
+                        aegean_outputs=aegean_outputs,
+                        reference_catalogue_directory=field_options.reference_catalogue_directory,
+                    )
 
     # zip up the final measurement set, which is not included in the above loop
     if field_options.zip_ms:

--- a/flint/summary.py
+++ b/flint/summary.py
@@ -101,8 +101,10 @@ def _get_pol_axis_as_rad(ms: Union[MS, Path]) -> float:
 
     try:
         pol_axis = get_pol_axis_from_ms(ms=ms, col="INSTRUMENT_RECEPTOR_ANGLE")
+        logger.info(f"INSTRUMENT_RECEPTOR_ANGLE obtained {pol_axis=}")
     except ValueError:
         pol_axis = get_pol_axis_from_ms(ms=ms, col="RECEPTOR_ANGLE")
+        logger.info(f"RECEPTOR_ANGLE obtained {pol_axis=}")
 
     return pol_axis.to(u.rad).value
 

--- a/flint/summary.py
+++ b/flint/summary.py
@@ -101,10 +101,13 @@ def _get_pol_axis_as_rad(ms: Union[MS, Path]) -> float:
 
     try:
         pol_axis = get_pol_axis_from_ms(ms=ms, col="INSTRUMENT_RECEPTOR_ANGLE")
-        logger.info(f"INSTRUMENT_RECEPTOR_ANGLE obtained {pol_axis=}")
+
+        logger.info(f"INSTRUMENT_RECEPTOR_ANGLE obtained pol_axis={pol_axis}")
     except ValueError:
         pol_axis = get_pol_axis_from_ms(ms=ms, col="RECEPTOR_ANGLE")
-        logger.info(f"RECEPTOR_ANGLE obtained {pol_axis=}")
+
+        # The prefect logger (or maybe the logger in general) does not render the quantity
+        logger.info(f"RECEPTOR_ANGLE obtained pol_axis={pol_axis}")
 
     return pol_axis.to(u.rad).value
 

--- a/flint/summary.py
+++ b/flint/summary.py
@@ -26,9 +26,9 @@ from flint.ms import (
     MS,
     MSSummary,
     describe_ms,
+    get_pol_axis_from_ms,
     get_telescope_location_from_ms,
     get_times_from_ms,
-    get_pol_axis_from_ms,
 )
 from flint.naming import get_sbid_from_path, processed_ms_format
 from flint.source_finding.aegean import AegeanOutputs

--- a/flint/validation.py
+++ b/flint/validation.py
@@ -1052,7 +1052,9 @@ def plot_field_info(
 
     hour_angles = field_summary.hour_angles
     elevations = field_summary.elevations
-
+    pol_axis_str = (
+        f"{field_summary.pol_axis:.3f} rad" if field_summary.pol_axis else "Unknown"
+    )
     field_text = "\n".join(
         (
             f"Field name: {field_summary.field_name}",
@@ -1068,6 +1070,7 @@ def plot_field_info(
             f"- Median rms uJy    : {rms_info.median*1e6:.1f}",
             f"- Components        : {len(askap_table)}",
             f"- Processing date   : {Time.now().fits}",
+            f"- Pol. axis         : {pol_axis_str}",
         )
     )
     props = dict(boxstyle="square", facecolor="none", edgecolor="tab:red", pad=2)

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -6,8 +6,8 @@ from astropy.io import fits
 
 from flint.masking import (
     MaskingOptions,
-    create_snr_mask_from_fits,
     _verify_set_positive_seed_clip,
+    create_snr_mask_from_fits,
 )
 from flint.naming import FITSMaskNames
 


### PR DESCRIPTION
The ASKAP third-axis (physical rotation) and rotation of the footprint (electronically rotated) together will place the instrumental response onto the sky in a particular direction. If the science field has a different alignment than the data collected during holography, there needs to be an alignment process when coadding images in order to properly apply the constrained holography beams to the same direction as the science field. 

This pull request aims to:
- pull out the pol axis from a measurement set
- carry this information through the pipeline
- pass it over to linmos, deriving the appropriate rotation using *an assumed* parameterisation of the holography beam alignment

This aims to address #86 