### PR TITLE
Masking and bane/aegean options

### DIFF
--- a/flint/data/tests/test_config.yaml
+++ b/flint/data/tests/test_config.yaml
@@ -68,7 +68,9 @@ selfcal:
     wsclean:
       data_column: "EXAMPLE"
     gaincal: {}
-    masking: {}
+    masking:
+      flood_fill_positive_seed_clip: 40
+      flood_fill_positive_flood_clip: 1.5
   2:
     wsclean:
       multiscale: false

--- a/flint/data/tests/test_config.yaml
+++ b/flint/data/tests/test_config.yaml
@@ -58,8 +58,8 @@ defaults:
     suppress_artefacts: true
     suppress_artefacts_negative_seed_clip: 5
     suppress_artefacts_guard_negative_dilation: 40
-    grow_low_snr_islands: true
-    grow_low_snr_clip: 1.75
+    grow_low_snr_island: true
+    grow_low_snr_island_clip: 1.75
     grow_low_snr_island_size: 768
 initial:
   wsclean: {}

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -111,7 +111,9 @@ class WSCleanOptions(NamedTuple):
     deconvolution_channels: Optional[int] = None
     """The channels out will be averaged down to this many sub-band images during deconvolution"""
     parallel_deconvolution: Optional[int] = None
-    """If not none, then this many channel images will be gridded together in parallel"""
+    """If not none, then this is the number of sub-regions wsclean will attempt to divide and clean"""
+    parallel_gridding: Optional[int] = None
+    """If not none, then this is the number of channel images that will be gridded in parallel"""
 
     def with_options(self, **kwargs) -> WSCleanOptions:
         """Return a new instance of WSCleanOptions with updated components"""

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -110,6 +110,8 @@ class WSCleanOptions(NamedTuple):
     """Path to a FITS file that encodes a cleaning mask"""
     deconvolution_channels: Optional[int] = None
     """The channels out will be averaged down to this many sub-band images during deconvolution"""
+    parallel_deconvolution: Optional[int] = None
+    """If not none, then this many channel images will be gridded together in parallel"""
 
     def with_options(self, **kwargs) -> WSCleanOptions:
         """Return a new instance of WSCleanOptions with updated components"""

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -403,7 +403,7 @@ def create_snr_mask_from_fits(
             negative_seed_clip=masking_options.suppress_artefacts_negative_seed_clip,
             guard_negative_dilation=masking_options.suppress_artefacts_guard_negative_dilation,
             grow_low_island=masking_options.grow_low_snr_island,
-            grow_low_snr=masking_options.grow_low_snr_island_clip,
+            grow_low_island_snr=masking_options.grow_low_snr_island_clip,
             grow_low_island_size=masking_options.grow_low_snr_island_size,
         )
         mask_data = mask_data.reshape(signal_data.shape)

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -187,6 +187,7 @@ def process_science_fields(
     )
     beam_summaries = task_create_beam_summary.map(ms=flagged_mss, imageset=wsclean_cmds)
 
+    beam_aegean_outputs = None
     if run_aegean:
         beam_aegean_outputs = task_run_bane_and_aegean.map(
             image=wsclean_cmds,
@@ -277,6 +278,10 @@ def process_science_fields(
                 field_options.use_beam_masks
                 and current_round >= field_options.use_beam_masks_from
             ):
+                masking_options = get_options_from_strategy(
+                    strategy=strategy, mode="masking", round=current_round
+                )
+                # NOTE: This might be run twice against the first set of images created
                 beam_aegean_outputs = task_run_bane_and_aegean.map(
                     image=wsclean_cmds,
                     aegean_container=unmapped(field_options.aegean_container),
@@ -285,6 +290,7 @@ def process_science_fields(
                     image=wsclean_cmds,
                     image_products=beam_aegean_outputs,
                     min_snr=3.5,
+                    update_masking_options=unmapped(masking_options),
                 )
 
             wsclean_cmds = task_wsclean_imager.map(

--- a/flint/source_finding/aegean.py
+++ b/flint/source_finding/aegean.py
@@ -17,10 +17,10 @@ from flint.sclient import run_singularity_command
 class BANEOptions(NamedTuple):
     """Container for basic BANE related options. Only a subclass of BANE options are supported."""
 
-    grid_size: Tuple[int, int] = (2, 2)
-    """The step interval of each box, in units of synthesised beams"""
-    box_size: Tuple[int, int] = (10, 10)
-    """The size of the box, which is in units of the grid size"""
+    grid_size: Tuple[int, int] = (8, 8)
+    """The step interval of each box, in pixels"""
+    box_size: Tuple[int, int] = (96, 96)
+    """The size of the box in pixels"""
 
 
 class AegeanOptions(NamedTuple):

--- a/flint/source_finding/aegean.py
+++ b/flint/source_finding/aegean.py
@@ -17,9 +17,9 @@ from flint.sclient import run_singularity_command
 class BANEOptions(NamedTuple):
     """Container for basic BANE related options. Only a subclass of BANE options are supported."""
 
-    grid_size: Tuple[int, int] = (8, 8)
+    grid_size: Optional[Tuple[int, int]] = None  # (8, 8)
     """The step interval of each box, in pixels"""
-    box_size: Tuple[int, int] = (196, 196)
+    box_size: Optional[Tuple[int, int]] = None  # (196, 196)
     """The size of the box in pixels"""
 
 
@@ -57,7 +57,16 @@ class AegeanOutputs(NamedTuple):
 def _get_bane_command(image: Path, cores: int, bane_options: BANEOptions) -> str:
     """Create the BANE command to run"""
     # The stripes is purposely set lower than the cores due to an outstanding bane bug that can cause a deadlock.
-    bane_command_str = f"BANE {str(image)} --cores {cores} --stripes {cores//2} --grid {bane_options.grid_size[0]} {bane_options.grid_size[1]} --box {bane_options.box_size[0]} {bane_options.box_size[1]}"
+    bane_command_str = f"BANE {str(image)} --cores {cores} --stripes {cores//2} "
+    if bane_options.grid_size:
+        bane_command_str += (
+            f"--grid {bane_options.grid_size[0]} {bane_options.grid_size[1]} "
+        )
+    if bane_options.box_size:
+        bane_command_str += (
+            f"--box {bane_options.box_size[0]} {bane_options.box_size[1]}"
+        )
+    bane_command_str = bane_command_str.rstrip()
     logger.info("Constructed bane command.")
 
     return bane_command_str

--- a/flint/source_finding/aegean.py
+++ b/flint/source_finding/aegean.py
@@ -51,7 +51,9 @@ def run_bane_and_aegean(
     aegean_names = create_aegean_names(base_output=base_output)
     logger.debug(f"{aegean_names=}")
 
-    bane_command_str = f"BANE {str(image)} --cores {cores} --stripes {cores//2}"
+    bane_command_str = (
+        f"BANE {str(image)} --cores {cores} --stripes {cores//2} --grid 2 --box 20"
+    )
     logger.info("Constructed BANE command. ")
 
     bind_dir = [image.absolute().parent]

--- a/flint/source_finding/aegean.py
+++ b/flint/source_finding/aegean.py
@@ -19,7 +19,7 @@ class BANEOptions(NamedTuple):
 
     grid_size: Tuple[int, int] = (8, 8)
     """The step interval of each box, in pixels"""
-    box_size: Tuple[int, int] = (96, 96)
+    box_size: Tuple[int, int] = (196, 196)
     """The size of the box in pixels"""
 
 

--- a/flint/source_finding/aegean.py
+++ b/flint/source_finding/aegean.py
@@ -52,7 +52,7 @@ def run_bane_and_aegean(
     logger.debug(f"{aegean_names=}")
 
     bane_command_str = (
-        f"BANE {str(image)} --cores {cores} --stripes {cores//2} --grid 2 --box 20"
+        f"BANE {str(image)} --cores {cores} --stripes {cores//2} --grid 2 2 --box 20 20"
     )
     logger.info("Constructed BANE command. ")
 

--- a/flint/source_finding/aegean.py
+++ b/flint/source_finding/aegean.py
@@ -2,7 +2,7 @@
 
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import NamedTuple, Tuple, Optional
+from typing import NamedTuple, Optional, Tuple
 
 from AegeanTools import BANE
 from AegeanTools.catalogs import save_catalog

--- a/tests/test_aegean.py
+++ b/tests/test_aegean.py
@@ -1,15 +1,15 @@
 """Tests around BANE and aegean, which are one of the source finding
 tools used in flint. BANE is also used to derive signal maps that ultimately
-feed the clean mask creation. 
+feed the clean mask creation.
 """
 
 from pathlib import Path
 
 from flint.source_finding.aegean import (
-    BANEOptions,
-    _get_bane_command,
     AegeanOptions,
+    BANEOptions,
     _get_aegean_command,
+    _get_bane_command,
 )
 
 

--- a/tests/test_aegean.py
+++ b/tests/test_aegean.py
@@ -28,6 +28,28 @@ def test_bane_options():
     assert expected == bane_str
 
 
+def test_bane_options_with_defaults():
+    bane_opts = BANEOptions()
+
+    assert isinstance(bane_opts, BANEOptions)
+
+    bane_str = _get_bane_command(
+        image=Path("this/is/a/test.fits"), cores=8, bane_options=bane_opts
+    )
+
+    assert isinstance(bane_str, str)
+
+    expected = "BANE this/is/a/test.fits --cores 8 --stripes 4"
+    assert expected == bane_str
+
+    bane_opts = BANEOptions(box_size=(3, 5))
+    bane_str = _get_bane_command(
+        image=Path("this/is/a/test.fits"), cores=8, bane_options=bane_opts
+    )
+    expected = "BANE this/is/a/test.fits --cores 8 --stripes 4 --box 3 5"
+    assert expected == bane_str
+
+
 def test_aegean_options():
     """Testing basic aegean options creation and expected command"""
     aegean_options = AegeanOptions(nocov=True, maxsummits=4, autoload=True)

--- a/tests/test_aegean.py
+++ b/tests/test_aegean.py
@@ -1,0 +1,53 @@
+"""Tests around BANE and aegean, which are one of the source finding
+tools used in flint. BANE is also used to derive signal maps that ultimately
+feed the clean mask creation. 
+"""
+
+from pathlib import Path
+
+from flint.source_finding.aegean import (
+    BANEOptions,
+    _get_bane_command,
+    AegeanOptions,
+    _get_aegean_command,
+)
+
+
+def test_bane_options():
+    bane_opts = BANEOptions(box_size=(2, 1), grid_size=(20, 10))
+
+    assert isinstance(bane_opts, BANEOptions)
+
+    bane_str = _get_bane_command(
+        image=Path("this/is/a/test.fits"), cores=8, bane_options=bane_opts
+    )
+
+    assert isinstance(bane_str, str)
+
+    expected = "BANE this/is/a/test.fits --cores 8 --stripes 4 --grid 20 10 --box 2 1"
+    assert expected == bane_str
+
+
+def test_aegean_options():
+    """Testing basic aegean options creation and expected command"""
+    aegean_options = AegeanOptions(nocov=True, maxsummits=4, autoload=True)
+
+    # This are silly tests
+    assert isinstance(aegean_options, AegeanOptions)
+    assert aegean_options.maxsummits == 4
+
+    ex_path = Path("this/is/a/test.fits")
+    aegean_command = _get_aegean_command(
+        image=ex_path, base_output="example", aegean_options=aegean_options
+    )
+
+    expected_cmd = "aegean this/is/a/test.fits --autoload --nocov --maxsummits 4 --table example.fits"
+    assert aegean_command == expected_cmd
+
+    aegean_options2 = AegeanOptions(nocov=False, maxsummits=40, autoload=False)
+    aegean_command2 = _get_aegean_command(
+        image=ex_path, base_output="example", aegean_options=aegean_options2
+    )
+
+    expected_cmd2 = "aegean this/is/a/test.fits --maxsummits 40 --table example.fits"
+    assert aegean_command2 == expected_cmd2

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -136,6 +136,31 @@ def test_get_options(strategy):
     assert wsclean["data_column"] == "CORRECTED_DATA"
 
 
+def test_get_mask_options(package_strategy):
+    """Basic test to prove masking operation behaves well"""
+    masking = get_options_from_strategy(
+        strategy=package_strategy, mode="masking", round="initial"
+    )
+
+    assert isinstance(masking, dict)
+    assert masking["flood_fill_positive_seed_clip"] == 4.5
+
+    masking2 = get_options_from_strategy(
+        strategy=package_strategy, mode="masking", round=1
+    )
+
+    print(strategy)
+
+    assert isinstance(masking2, dict)
+    assert masking2["flood_fill_positive_seed_clip"] == 40
+
+    for k in masking.keys():
+        if k == "flood_fill_positive_seed_clip":
+            continue
+
+        assert masking[k] == masking2[k]
+
+
 def test_get_modes(package_strategy):
     # makes sure defaults for these modes are return when reuestion options
     # on a self-cal round without them set


### PR DESCRIPTION
Noticed some strange failure modes which expressed themselves as wsclean diverging throughout clean. It took a few attempts of isolating the problem, but it ultimately turned out to be that the strategy masking options were not being passed through to the masking functionality to derive clean masks. 

In this pull request there are two main changes:
- plugging in the `MaskingOptions` from the strategy file to the actual masking function
- the start of BANEOptions and AegeanOptions

On the section point, these are not exposed in the interface to / from the strategy file. These will come in a future request. 

This should address #98 