### PR TITLE
Added pixels per beam, masking_options, and large_island_threshold

### DIFF
--- a/flint/masking.py
+++ b/flint/masking.py
@@ -237,7 +237,7 @@ def suppress_artefact_mask(
         small_islands = [
             idx
             for idx, count in enumerate(counts)
-            if count > 2 * pixels_per_beam and idx > 0
+            if count > 5 * pixels_per_beam and idx > 0
         ]
         negative_mask[~np.isin(mask_labels, small_islands)] = False
 

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -238,7 +238,7 @@ def suppress_artefact_mask(
 
         clip_pixels_threshold = large_island_threshold * pixels_per_beam
         logger.info(
-            f"Removing negative islands larger than {clip_pixels_threshold} with {large_island_threshold=}, {pixels_per_beam=}"
+            f"Removing negative islands larger than {clip_pixels_threshold} pixels with {large_island_threshold=}, {pixels_per_beam=}"
         )
 
         large_islands = [

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -67,9 +67,12 @@ def task_potato_peel(
     potato_container: Path,
     update_potato_config_options: Optional[Dict[str, Any]] = None,
     update_potato_peel_options: Optional[Dict[str, Any]] = None,
-    update_wsclean_options: Optional[WSCleanOptions] = None,
+    update_wsclean_options: Optional[Dict[str, Any]] = None,
 ) -> MS:
     logger.info(f"Attempting to peel {ms.path}")
+
+    if update_wsclean_options is None:
+        update_wsclean_options = {}
 
     wsclean_options = WSCleanOptions(**update_wsclean_options)
 

--- a/flint/sclient.py
+++ b/flint/sclient.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from socket import gethostname
 from subprocess import CalledProcessError
+from time import sleep
 from typing import Callable, Collection, Optional, Union
 
 from spython.main import Client as sclient
@@ -66,6 +67,10 @@ def run_singularity_command(
             logger.info(line.rstrip())
             if stream_callback_func:
                 stream_callback_func(line)
+
+        # Sleep for a few moments. If the command created files (often they do), give the lustre a moment
+        # to properly register them. You dirty sea dog.
+        sleep(2.0)
     except CalledProcessError as e:
         logger.error(f"Failed to run command: {command}")
         logger.error(f"Stdout: {e.stdout}")

--- a/flint/source_finding/aegean.py
+++ b/flint/source_finding/aegean.py
@@ -4,9 +4,6 @@ from argparse import ArgumentParser
 from pathlib import Path
 from typing import NamedTuple, Optional, Tuple
 
-from AegeanTools import BANE
-from AegeanTools.catalogs import save_catalog
-from AegeanTools.source_finder import SourceFinder
 from astropy.io import fits
 
 from flint.logging import logger

--- a/flint/utils.py
+++ b/flint/utils.py
@@ -13,9 +13,8 @@ from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.wcs import WCS
 
-from flint.logging import logger
 from flint.convol import BeamShape
-
+from flint.logging import logger
 
 # TODO: This Captain is aware that there is a common fits getheader between
 # a couple of functions that interact with tasks. Perhaps a common FITS properties

--- a/tests/test_aegean.py
+++ b/tests/test_aegean.py
@@ -29,7 +29,7 @@ def test_bane_options():
 
 
 def test_bane_options_with_defaults():
-    bane_opts = BANEOptions()
+    bane_opts = BANEOptions(box_size=None, grid_size=None)
 
     assert isinstance(bane_opts, BANEOptions)
 
@@ -42,7 +42,7 @@ def test_bane_options_with_defaults():
     expected = "BANE this/is/a/test.fits --cores 8 --stripes 4"
     assert expected == bane_str
 
-    bane_opts = BANEOptions(box_size=(3, 5))
+    bane_opts = BANEOptions(box_size=(3, 5), grid_size=None)
     bane_str = _get_bane_command(
         image=Path("this/is/a/test.fits"), cores=8, bane_options=bane_opts
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 """Basic tests for utility functions"""
 
+import math
 from pathlib import Path
 
 import astropy.units as u
@@ -11,11 +12,14 @@ from astropy.wcs import WCS
 
 from flint.logging import logger
 from flint.utils import (
+    get_beam_shape,
+    get_pixels_per_beam,
     estimate_skycoord_centre,
     generate_strict_stub_wcs_header,
     generate_stub_wcs_header,
     get_packaged_resource_path,
 )
+from flint.convol import BeamShape
 
 
 @pytest.fixture
@@ -28,6 +32,24 @@ def rms_path(tmpdir):
     )
 
     return rms_path
+
+
+def test_pixels_per_beam(rms_path):
+    """Confirm pixels per beam is working"""
+    no_pixels = get_pixels_per_beam(fits_path=rms_path)
+
+    assert np.isclose(math.floor(no_pixels), 51.0)
+    assert no_pixels > 0.0
+
+
+def test_get_beam_shape(rms_path):
+    """Test to ensure the beam can be extracted from input image"""
+    beam = get_beam_shape(fits_path=rms_path)
+
+    assert isinstance(beam, BeamShape)
+    assert np.isclose(10.90918, beam.bmaj_arcsec)
+    assert np.isclose(9.346510, beam.bmin_arcsec)
+    assert np.isclose(56.2253417, beam.bpa_deg)
 
 
 def test_generate_strict_header_position():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,16 +10,16 @@ from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.wcs import WCS
 
+from flint.convol import BeamShape
 from flint.logging import logger
 from flint.utils import (
-    get_beam_shape,
-    get_pixels_per_beam,
     estimate_skycoord_centre,
     generate_strict_stub_wcs_header,
     generate_stub_wcs_header,
+    get_beam_shape,
     get_packaged_resource_path,
+    get_pixels_per_beam,
 )
-from flint.convol import BeamShape
 
 
 @pytest.fixture


### PR DESCRIPTION
Something crossed my mind and made me think having some awareness of number of pixels per beam would be useful, particularly when attempting to construct clean masks. 

At the moment I am only using it when attempting to craft a mask that suppresses artefacts, but can also be used when looking for large faint islands. 

This comes with a re-tweak that relies a little more on the MaskingOptions class. 