### PR TITLE
Add initial archiving functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Most of the `python` routines have a CLI that can be used to test them in a piec
 - `flint_validation_plot`: Create a simple, quick look figure that expresses the key quality statistics of an image. It is intended to be used against a full continuum field image, but in-principal be used for a per beam image.
 - `flint_potato`: Attempt to peel out known sources from a measurement set using [potatopeel](
 https://gitlab.com/Sunmish/potato/-/tree/main). Criteria used to assess which sources to peel is fairly minimumal, and at the time of writing only the reference set of sources paackaged within `flint` are considered.
+-`flint_archive`: Operations around archiving and copying final data products into place.
 
 The following commands use the `prefect` framework to link together individual tasks together (outlined above) into a single data-processing pipeline.
 - `flint_flow_bandpass_calibrate`: Executes a prefect flow run that will calibrate a set of ASKAP measurement sets taken during a normal bandpass observation sequence.

--- a/flint/archive.py
+++ b/flint/archive.py
@@ -72,10 +72,12 @@ def tar_files_into(tar_out_path: Path, files_to_tar: Collection[Path]) -> Path:
     # Create the output directory in case it does not exist
     tar_out_path.parent.mkdir(parents=True, exist_ok=True)
 
+    total = len(files_to_tar)
+    logger.info(f"Taring {total} files")
     logger.info(f"Opening {tar_out_path}")
     with tarfile.open(tar_out_path, "w") as tar:
-        for file in files_to_tar:
-            logger.info(f"Adding {str(file)}")
+        for count, file in enumerate(files_to_tar):
+            logger.info(f"{count+1} of {total}, adding {str(file)}")
             tar.add(file, arcname=file.name)
 
     return tar_out_path

--- a/flint/archive.py
+++ b/flint/archive.py
@@ -156,8 +156,6 @@ def cli() -> None:
 
     args = parser.parse_args()
 
-    logger.info(args)
-
     if args.mode == "list":
         archive_options = ArchiveOptions(file_globs=args.file_globs)
 

--- a/flint/archive.py
+++ b/flint/archive.py
@@ -3,11 +3,8 @@
 import shutil
 import tarfile
 from argparse import ArgumentParser
-from glob import glob
 from pathlib import Path
 from typing import Collection, List, NamedTuple, Tuple
-
-from sklearn import base
 
 from flint.logging import logger
 

--- a/flint/archive.py
+++ b/flint/archive.py
@@ -145,7 +145,7 @@ def get_parser() -> ArgumentParser:
         nargs="+",
         default=DEFAULT_GLOB_EXPRESSIONS,
         type=str,
-        help="The glob expressions to evaluate",
+        help="The glob expressions to evaluate inside the base path directory",
     )
 
     return parser
@@ -155,6 +155,8 @@ def cli() -> None:
     parser = get_parser()
 
     args = parser.parse_args()
+
+    logger.info(args)
 
     if args.mode == "list":
         archive_options = ArchiveOptions(file_globs=args.file_globs)

--- a/flint/archive.py
+++ b/flint/archive.py
@@ -10,23 +10,25 @@ from sklearn import base
 
 from flint.logging import logger
 
+DEFAULT_GLOB_EXPRESSIONS = ("*fits", "*png", "*.ms.zip")
+
 
 class ArchiveOptions(NamedTuple):
     """Container for options related to archiving products from flint workflows"""
 
-    file_globs: Collection[str] = ("*fits", "*png", "*.ms.zip")
+    file_globs: Collection[str] = DEFAULT_GLOB_EXPRESSIONS
     """Glob expressions to use to collect files that should be tarballed"""
 
 
 def resolve_glob_expressions(
-    base_path: Path, glob_expressions: Collection[str]
+    base_path: Path, file_globs: Collection[str]
 ) -> Tuple[Path, ...]:
     """Collect a set of files given a base directory and a set of glob expressions. Unique
     paths are returned.
 
     Args:
         base_path (Path): The base folder with files to consider
-        glob_expressions (Collection[str]): An iterable with a set of glob expressions to evaluate
+        filke_globs (Collection[str]): An iterable with a set of glob expressions to evaluate
 
     Returns:
         Tuple[Path,...]: Unique collection of paths
@@ -37,11 +39,11 @@ def resolve_glob_expressions(
 
     logger.info(f"Searching {base_path=}")
 
-    for glob_expression in glob_expressions:
+    for glob_expression in file_globs:
         resolved_files.extend(list(base_path.glob(glob_expression)))
 
     logger.info(
-        f"Resolved {len(resolved_files)} files from {len(glob_expressions)} expressions in {base_path=}"
+        f"Resolved {len(resolved_files)} files from {len(file_globs)} expressions in {base_path=}"
     )
 
     return tuple(set(resolved_files))
@@ -54,6 +56,22 @@ def get_parser() -> ArgumentParser:
         dest="mode", help="Operation mode of flint_archive"
     )
 
+    list_parser = subparser.add_parser("list")
+    list_parser.add_argument(
+        "--base-path",
+        type=Path,
+        default=Path("."),
+        help="Base directory to perform glob expressions",
+    )
+
+    list_parser.add_argument(
+        "--file-globs",
+        nargs="+",
+        default=DEFAULT_GLOB_EXPRESSIONS,
+        type=str,
+        help="The glob expressions to evaluate",
+    )
+
     return parser
 
 
@@ -61,6 +79,16 @@ def cli() -> None:
     parser = get_parser()
 
     args = parser.parse_args()
+
+    if args.mode == "list":
+        archive_options = ArchiveOptions(file_globs=args.file_globs)
+
+        files = resolve_glob_expressions(
+            base_path=args.base_path, file_globs=archive_options.file_globs
+        )
+
+        for file in sorted(files):
+            logger.info(f"{file}")
 
 
 if __name__ == "__main__":

--- a/flint/archive.py
+++ b/flint/archive.py
@@ -10,7 +10,14 @@ from sklearn import base
 
 from flint.logging import logger
 
-DEFAULT_GLOB_EXPRESSIONS = ("*fits", "*png", "*.ms.zip")
+DEFAULT_GLOB_EXPRESSIONS = (
+    "*image*fits",
+    "*linmos*",
+    "*yaml",
+    "*.txt",
+    "*png",
+    "*.ms.zip",
+)
 
 
 class ArchiveOptions(NamedTuple):

--- a/flint/archive.py
+++ b/flint/archive.py
@@ -268,6 +268,14 @@ def cli() -> None:
             base_path=args.base_path,
             archive_options=archive_options,
         )
+    elif args.mode == "copy":
+        archive_options = ArchiveOptions(copy_file_globs=args.copy_file_globs)
+
+        copy_sbid_files_archive(
+            copy_out_path=args.copy_out_path,
+            base_path=args.base_path,
+            archive_options=archive_options,
+        )
 
     else:
         parser.print_help()

--- a/flint/archive.py
+++ b/flint/archive.py
@@ -1,11 +1,11 @@
 """Operations around preserving files and products from an flint run"""
 
-import tarfile
 import shutil
+import tarfile
 from argparse import ArgumentParser
 from glob import glob
 from pathlib import Path
-from typing import NamedTuple, Collection, List, Tuple
+from typing import Collection, List, NamedTuple, Tuple
 
 from sklearn import base
 

--- a/flint/options.py
+++ b/flint/options.py
@@ -100,3 +100,7 @@ class FieldOptions(NamedTuple):
     """If `use_beam_masks` is True, start using them from this round of self-calibration"""
     imaging_strategy: Optional[Path] = None
     """Path to a FLINT imaging yaml file that contains settings to use throughout imaging"""
+    sbid_archive_path: Optional[Path] = None
+    """Path that SBID archive tarballs will be created under. If None no archive tarballs are created. See ArchiveOptions. """
+    sbid_copy_path: Optional[Path] = None
+    """Path that final processed products will be copied into. If None no copying of file products is performed. See ArchiveOptions. """

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -702,13 +702,15 @@ def _validation_items(
         reference_catalogue_directory (Path): Location of directory containing the reference known NVSS, SUMSS and ICRS catalogues
     """
 
-    task_create_validation_plot.submit(
+    val_plot_path = task_create_validation_plot.submit(
         field_summary=field_summary,
         aegean_outputs=aegean_outputs,
         reference_catalogue_directory=reference_catalogue_directory,
     )
-    task_create_validation_tables.submit(
+    validate_tables = task_create_validation_tables.submit(
         field_summary=field_summary,
         aegean_outputs=aegean_outputs,
         reference_catalogue_directory=reference_catalogue_directory,
     )
+
+    return (val_plot_path, validate_tables)

--- a/flint/prefect/common/utils.py
+++ b/flint/prefect/common/utils.py
@@ -8,6 +8,11 @@ from uuid import UUID
 from prefect import task
 from prefect.artifacts import create_markdown_artifact
 
+from flint.archive import (
+    ArchiveOptions,
+    create_sbid_tar_archive,
+    copy_sbid_files_archive,
+)
 from flint.logging import logger
 from flint.summary import (
     create_beam_summary,
@@ -63,6 +68,41 @@ task_create_beam_summary = task(create_beam_summary)
 
 # Intended to represent objects with a .with_options() interface
 T = TypeVar("T")
+
+
+@task
+def task_archive_sbid(
+    science_folder_path: Path,
+    archive_path: Optional[Path] = None,
+    copy_path: Optional[Path] = None,
+) -> Path:
+    """Create a tarbal of files, or copy files, from a processing folder.
+
+    Args:
+        science_folder_path (Path): Path that contains the imaged produced
+        archive_path (Optional[Path], optional): Location to create and store the tar ball at. If None no tarball is created. Defaults to None.
+        copy_path (Optional[Path], optional): Location to copy selected files into. If None no files are copied. Defaults to None.
+
+    Returns:
+        Path: The science folder files were copied from
+    """
+
+    archive_options = ArchiveOptions()
+    if archive_path:
+        create_sbid_tar_archive(
+            tar_out_path=archive_path,
+            base_path=science_folder_path,
+            archive_options=archive_options,
+        )
+
+    if copy_path:
+        copy_sbid_files_archive(
+            copy_out_path=copy_path,
+            base_path=science_folder_path,
+            archive_options=archive_options,
+        )
+
+    return science_folder
 
 
 @task

--- a/flint/prefect/common/utils.py
+++ b/flint/prefect/common/utils.py
@@ -14,10 +14,12 @@ from flint.archive import (
     copy_sbid_files_archive,
 )
 from flint.logging import logger
+from flint.naming import get_sbid_from_path
 from flint.summary import (
     create_beam_summary,
     create_field_summary,
     update_field_summary,
+    FieldSummary,
 )
 
 T = TypeVar("T")
@@ -73,6 +75,7 @@ T = TypeVar("T")
 @task
 def task_archive_sbid(
     science_folder_path: Path,
+    field_summary: FieldSummary,
     archive_path: Optional[Path] = None,
     copy_path: Optional[Path] = None,
 ) -> Path:
@@ -87,10 +90,15 @@ def task_archive_sbid(
         Path: The science folder files were copied from
     """
 
+    sbid = field_summary.sbid
+    p_sbid = get_sbid_from_path(path=science_folder_path)
+
+    logger.info(f"{sbid} {p_sbid}")
+
     archive_options = ArchiveOptions()
     if archive_path:
         create_sbid_tar_archive(
-            tar_out_path=archive_path,
+            tar_out_path=Path(archive_path) / f"{sbid}.tar",
             base_path=science_folder_path,
             archive_options=archive_options,
         )

--- a/flint/prefect/common/utils.py
+++ b/flint/prefect/common/utils.py
@@ -10,11 +10,11 @@ from prefect.artifacts import create_markdown_artifact
 
 from flint.archive import (
     ArchiveOptions,
-    create_sbid_tar_archive,
     copy_sbid_files_archive,
+    create_sbid_tar_archive,
 )
 from flint.logging import logger
-from flint.naming import get_sbid_from_path, add_timestamp_to_path
+from flint.naming import add_timestamp_to_path, get_sbid_from_path
 from flint.summary import (
     create_beam_summary,
     create_field_summary,

--- a/flint/prefect/common/utils.py
+++ b/flint/prefect/common/utils.py
@@ -14,12 +14,11 @@ from flint.archive import (
     copy_sbid_files_archive,
 )
 from flint.logging import logger
-from flint.naming import get_sbid_from_path
+from flint.naming import get_sbid_from_path, add_timestamp_to_path
 from flint.summary import (
     create_beam_summary,
     create_field_summary,
     update_field_summary,
-    FieldSummary,
 )
 
 T = TypeVar("T")
@@ -75,7 +74,6 @@ T = TypeVar("T")
 @task
 def task_archive_sbid(
     science_folder_path: Path,
-    field_summary: FieldSummary,
     archive_path: Optional[Path] = None,
     copy_path: Optional[Path] = None,
 ) -> Path:
@@ -90,15 +88,13 @@ def task_archive_sbid(
         Path: The science folder files were copied from
     """
 
-    sbid = field_summary.sbid
-    p_sbid = get_sbid_from_path(path=science_folder_path)
-
-    logger.info(f"{sbid} {p_sbid}")
+    sbid = get_sbid_from_path(path=science_folder_path)
 
     archive_options = ArchiveOptions()
     if archive_path:
+        tar_file_name = add_timestamp_to_path(Path(archive_path) / f"{sbid}.tar")
         create_sbid_tar_archive(
-            tar_out_path=Path(archive_path) / f"{sbid}.tar",
+            tar_out_path=tar_file_name,
             base_path=science_folder_path,
             archive_options=archive_options,
         )

--- a/flint/prefect/common/utils.py
+++ b/flint/prefect/common/utils.py
@@ -102,7 +102,7 @@ def task_archive_sbid(
             archive_options=archive_options,
         )
 
-    return science_folder
+    return science_folder_path
 
 
 @task

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -382,7 +382,6 @@ def process_science_fields(
             science_folder_path=output_split_science_path,
             archive_path=field_options.sbid_archive_path,
             copy_path=field_options.sbid_copy_path,
-            field_summary=field_summary,
             wait_for=archive_wait_for,
         )
 

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -234,7 +234,7 @@ def process_science_fields(
                 linmos_command=parset,
             )
             archive_wait_for.extend(linmos_field_summary)
-            
+
             if run_validation and field_options.reference_catalogue_directory:
                 _validation_items(
                     field_summary=linmos_field_summary,
@@ -313,7 +313,7 @@ def process_science_fields(
                 fits_mask=fits_beam_masks,
             )
             archive_wait_for.extend(wsclean_cmds)
-            
+
             # Do source finding on the last round of self-cal'ed images
             if round == field_options.rounds and run_aegean:
                 task_run_bane_and_aegean.map(
@@ -372,8 +372,7 @@ def process_science_fields(
                         aegean_outputs=aegean_outputs,
                         reference_catalogue_directory=field_options.reference_catalogue_directory,
                     )
-                    archive_wait_for.append(val_results))
-                    
+                    archive_wait_for.append(val_results)
 
     # zip up the final measurement set, which is not included in the above loop
     if field_options.zip_ms:

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -233,7 +233,7 @@ def process_science_fields(
                 aegean_outputs=aegean_field_output,
                 linmos_command=parset,
             )
-            archive_wait_for.extend(linmos_field_summary)
+            archive_wait_for.append(linmos_field_summary)
 
             if run_validation and field_options.reference_catalogue_directory:
                 _validation_items(
@@ -410,6 +410,8 @@ def setup_run_process_science_field(
         split_path=split_path,
         field_options=field_options,
     )
+
+    # TODO: Put the archive stuff here?
 
 
 def get_parser() -> ArgumentParser:

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -344,7 +344,7 @@ def process_science_fields(
                 cutoff=field_options.pb_cutoff,
                 field_summary=field_summary,
             )
-            archive_wait_for.extend(parset)
+            archive_wait_for.append(parset)
 
             if field_options.linmos_residuals:
                 _convolve_linmos_residuals(

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -6,7 +6,7 @@
 """
 
 from pathlib import Path
-from typing import Union, List, Any
+from typing import Any, List, Union
 
 from configargparse import ArgumentParser
 from prefect import flow, tags, unmapped

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -253,6 +253,7 @@ def process_science_fields(
 
     # Set up the default value should the user activated mask option is not set
     fits_beam_masks = None
+    linmos_field_summary = None
 
     for current_round in range(1, field_options.rounds + 1):
         with tags(f"selfcal-{current_round}"):
@@ -370,12 +371,18 @@ def process_science_fields(
     if field_options.zip_ms:
         task_zip_ms.map(in_item=wsclean_cmds)
 
-    if field_options.sbid_archive_path or field_options.sbid_copy_path:
+    if field_options.sbid_archive_path or field_options.sbid_copy_path and run_aegean:
+        # TODO: refine how this is 'waited for'
+        wait_for = (
+            (val_results, linmos_field_summary)
+            if val_results
+            else (linmos_field_summary,)
+        )
         task_archive_sbid.submit(
             science_folder_path=output_split_science_path,
             archive_path=field_options.sbid_archive_path,
             copy_path=field_options.sbid_copy_path,
-            wait_for=(val_results, linmos_field_summary),  # type: ignore
+            wait_for=wait_for,
         )
 
 

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -258,7 +258,6 @@ def process_science_fields(
 
     # Set up the default value should the user activated mask option is not set
     fits_beam_masks = None
-    linmos_field_summary = None
 
     for current_round in range(1, field_options.rounds + 1):
         with tags(f"selfcal-{current_round}"):

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -382,6 +382,7 @@ def process_science_fields(
             science_folder_path=output_split_science_path,
             archive_path=field_options.sbid_archive_path,
             copy_path=field_options.sbid_copy_path,
+            field_summary=field_summary,
             wait_for=archive_wait_for,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry.scripts]
 flint_skymodel = "flint.sky_model:cli"
 flint_aocalibrate = "flint.calibrate.aocalibrate:cli"
+flint_archive = "flint.archive:cli"
 flint_flagger = "flint.flagging:cli"
 flint_bandpass = "flint.bandpass:cli"
 flint_ms = "flint.ms:cli"

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,17 +1,18 @@
 """Tests around archives"""
 
-import pytest
 import tarfile
 from pathlib import Path
 
+import pytest
+
 from flint.archive import (
-    ArchiveOptions,
-    create_sbid_tar_archive,
-    resolve_glob_expressions,
-    get_parser,
-    tar_files_into,
-    copy_files_into,
     DEFAULT_GLOB_EXPRESSIONS,
+    ArchiveOptions,
+    copy_files_into,
+    create_sbid_tar_archive,
+    get_parser,
+    resolve_glob_expressions,
+    tar_files_into,
 )
 
 FILES = [f"some_file_{a:02d}-image.fits" for a in range(36)] + [

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -10,6 +10,7 @@ from flint.archive import (
     resolve_glob_expressions,
     get_parser,
     tar_files_into,
+    copy_files_into,
     DEFAULT_GLOB_EXPRESSIONS,
 )
 
@@ -40,6 +41,20 @@ def temp_files(glob_files):
     )
 
     return (base_dir, resolved)
+
+
+def test_copy_files_into(tmpdir, temp_files):
+    """Basic sanity checks to the copying process"""
+    base_dir, files = temp_files
+
+    tmpdir = Path(tmpdir)
+    copy_out = tmpdir / "copy_location"
+
+    copy_files_into(copy_out_path=copy_out, files_to_copy=files)
+
+    files_copied = list(copy_out.glob("*"))
+    assert len(files_copied) == len(files)
+    assert len(files_copied) > 0
 
 
 def test_glob_expressions(glob_files):


### PR DESCRIPTION
In preparation for running jobs automatically, it has become apparent that archiving options are needed. This pull request adds functions to:
- tarball up selected files resolved from glob expressions from a processing directory
- copy selected files resolved from glob expressions into a final location

There is a new `ArchiveOptions` class used to help control and interface into these functions. At the moment the list of files that will be copied are hard-coded across 4 or 5 glob expressions. 

This has also been patched into the typical continuum pipeline, but I think that there are better ways of implementing this. Perhaps as a separate flow that is called after the initial larger workflow. 