### PR TITLE
Regular expression patterns instead of glob

### DIFF
--- a/flint/archive.py
+++ b/flint/archive.py
@@ -130,6 +130,7 @@ def tar_files_into(tar_out_path: Path, files_to_tar: Collection[Path]) -> Path:
             logger.info(f"{count+1} of {total}, adding {str(file)}")
             tar.add(file, arcname=file.name)
 
+    logger.info(f"Created {tar_out_path}")
     return tar_out_path
 
 
@@ -198,11 +199,11 @@ def get_parser() -> ArgumentParser:
     )
 
     list_parser.add_argument(
-        "--file-globs",
+        "--file-patterns",
         nargs="+",
         default=DEFAULT_TAR_RE_PATTERNS,
         type=str,
-        help="The glob expressions to evaluate",
+        help="The regular expression patterns to evaluate",
     )
 
     create_parser = subparser.add_parser("create", help="Create a tarfile archive")
@@ -217,11 +218,11 @@ def get_parser() -> ArgumentParser:
     )
 
     create_parser.add_argument(
-        "--file-globs",
+        "--tar-file-patterns",
         nargs="+",
         default=DEFAULT_TAR_RE_PATTERNS,
         type=str,
-        help="The glob expressions to evaluate inside the base path directory",
+        help="The regular expression patterns to evaluate inside the base path directory",
     )
 
     create_parser = subparser.add_parser(
@@ -240,11 +241,11 @@ def get_parser() -> ArgumentParser:
     )
 
     create_parser.add_argument(
-        "--copy-file-globs",
+        "--copy-file-patterns",
         nargs="+",
         default=DEFAULT_COPY_RE_PATTERNS,
         type=str,
-        help="The glob expressions to evaluate inside the base path directory",
+        help="The regular expression patterns to evaluate inside the base path directory",
     )
 
     return parser

--- a/flint/archive.py
+++ b/flint/archive.py
@@ -267,7 +267,7 @@ def cli() -> None:
         for file in sorted(files):
             logger.info(f"{file}")
     elif args.mode == "create":
-        archive_options = ArchiveOptions(tar_file_re_patterns=args.file_globs)
+        archive_options = ArchiveOptions(tar_file_re_patterns=args.tar_file_patterns)
 
         create_sbid_tar_archive(
             tar_out_path=args.tar_out_path,

--- a/flint/archive.py
+++ b/flint/archive.py
@@ -257,7 +257,7 @@ def cli() -> None:
     args = parser.parse_args()
 
     if args.mode == "list":
-        archive_options = ArchiveOptions(tar_file_re_patterns=args.file_globs)
+        archive_options = ArchiveOptions(tar_file_re_patterns=args.file_patters)
 
         files = resolve_glob_expressions(
             base_path=args.base_path,

--- a/flint/archive.py
+++ b/flint/archive.py
@@ -184,7 +184,9 @@ def copy_sbid_files_archive(
 
 
 def get_parser() -> ArgumentParser:
-    parser = ArgumentParser(description="Operations around archiving")
+    parser = ArgumentParser(
+        description="Operations around archiving. Patterns are specified as regular expressions (not globs). "
+    )
 
     subparser = parser.add_subparsers(
         dest="mode", help="Operation mode of flint_archive"

--- a/flint/archive.py
+++ b/flint/archive.py
@@ -1,16 +1,21 @@
 """Operations around preserving files and products from an flint run"""
 
+from __future__ import (  # Used for mypy/pylance to like the return type of MS.with_options
+    annotations,
+)
+
 import re
 import shutil
 import tarfile
 from argparse import ArgumentParser
 from pathlib import Path
+from turtle import update
 from typing import Collection, List, NamedTuple, Tuple
 
 from flint.logging import logger
 
 DEFAULT_TAR_RE_PATTERNS = (
-    r".*image.*fits",
+    r".*MFS.*image.*fits",
     r".*linmos.*",
     r".*yaml",
     r".*\.txt",
@@ -27,6 +32,12 @@ class ArchiveOptions(NamedTuple):
     """Regular-expressions to use to collect files that should be tarballed"""
     copy_file_re_patterns: Collection[str] = DEFAULT_COPY_RE_PATTERNS
     """Regular-expressions used to identify files to copy into a final location (not tarred)"""
+
+    def with_options(self, **kwargs) -> ArchiveOptions:
+        opts = self._asdict()
+        opts.update(**kwargs)
+
+        return ArchiveOptions(**opts)
 
 
 def resolve_glob_expressions(

--- a/flint/archive.py
+++ b/flint/archive.py
@@ -266,8 +266,8 @@ def cli() -> None:
             file_re_patterns=archive_options.tar_file_re_patterns,
         )
 
-        for file in sorted(files):
-            logger.info(f"{file}")
+        for count, file in enumerate(sorted(files)):
+            logger.info(f"{count} of {len(files)}, {file}")
     elif args.mode == "create":
         archive_options = ArchiveOptions(tar_file_re_patterns=args.tar_file_patterns)
 

--- a/flint/archive.py
+++ b/flint/archive.py
@@ -9,7 +9,6 @@ import shutil
 import tarfile
 from argparse import ArgumentParser
 from pathlib import Path
-from turtle import update
 from typing import Collection, List, NamedTuple, Tuple
 
 from flint.logging import logger

--- a/flint/archive.py
+++ b/flint/archive.py
@@ -74,7 +74,7 @@ def resolve_glob_expressions(
         f"Resolved {len(resolved_files)} files from {len(file_re_patterns)} expressions in {base_path=}"
     )
 
-    return tuple([Path(p) for p in set(resolved_files)])
+    return tuple(sorted([Path(p) for p in set(resolved_files)]))
 
 
 def copy_files_into(copy_out_path: Path, files_to_copy: Collection[Path]) -> Path:

--- a/flint/archive.py
+++ b/flint/archive.py
@@ -1,5 +1,6 @@
 """Operations around preserving files and products from an flint run"""
 
+import re
 import shutil
 import tarfile
 from argparse import ArgumentParser
@@ -9,12 +10,12 @@ from typing import Collection, List, NamedTuple, Tuple
 from flint.logging import logger
 
 DEFAULT_GLOB_EXPRESSIONS = (
-    "*image*fits",
-    "*linmos*",
-    "*yaml",
-    "*.txt",
-    "*png",
-    "*.ms.zip",
+    r".*image.*fits",
+    r".*linmos.*",
+    r".*yaml",
+    r".*\.txt",
+    r".*png",
+    r".*\.ms\.zip",
 )
 DEFAULT_COPY_GLOB_EXPRESSIONS = ("*linmos*fits", "*png")
 
@@ -47,9 +48,14 @@ def resolve_glob_expressions(
 
     logger.info(f"Searching {base_path=}")
 
+    all_files = list(base_path.glob("*"))
+    logger.info(f"{len(all_files)} total files and {len(file_globs)} to consider")
+
     for glob_expression in file_globs:
         logger.info(f"Using expression: {glob_expression}")
-        resolved_files.extend(list(base_path.glob(glob_expression)))
+        resolved_files.extend(
+            [f for f in all_files if re.search(glob_expression, str(f.name))]
+        )
 
     logger.info(
         f"Resolved {len(resolved_files)} files from {len(file_globs)} expressions in {base_path=}"

--- a/flint/archive.py
+++ b/flint/archive.py
@@ -48,7 +48,7 @@ def resolve_glob_expressions(
 
     logger.info(f"Searching {base_path=}")
 
-    all_files = list(base_path.glob("*"))
+    all_files = list(base_path.iterdir())
     logger.info(f"{len(all_files)} total files and {len(file_re_patterns)} to consider")
 
     for reg_expression in file_re_patterns:

--- a/flint/archive.py
+++ b/flint/archive.py
@@ -14,6 +14,8 @@ from typing import Collection, List, NamedTuple, Tuple
 
 from flint.logging import logger
 
+# TODO: Perhaps move these to flint.naming, and can be built up
+# based on rules, e.g. imager used, source finder etc.
 DEFAULT_TAR_RE_PATTERNS = (
     r".*MFS.*image.*fits",
     r".*linmos.*",

--- a/flint/archive.py
+++ b/flint/archive.py
@@ -259,7 +259,7 @@ def cli() -> None:
     args = parser.parse_args()
 
     if args.mode == "list":
-        archive_options = ArchiveOptions(tar_file_re_patterns=args.file_patters)
+        archive_options = ArchiveOptions(tar_file_re_patterns=args.file_patterns)
 
         files = resolve_glob_expressions(
             base_path=args.base_path,

--- a/flint/naming.py
+++ b/flint/naming.py
@@ -100,7 +100,9 @@ class ProcessedNameComponents(NamedTuple):
     """The self-calibration round detected. This might be represented as 'noselfcal' in some image products, e.g. linmos. """
 
 
-def processed_ms_format(in_name: Union[str, Path]) -> ProcessedNameComponents:
+def processed_ms_format(
+    in_name: Union[str, Path]
+) -> Union[ProcessedNameComponents, None]:
     """Will take a formatted name (i.e. one derived from the flint.naming.create_ms_name)
     and attempt to extract its main components. This includes the SBID, field, beam and spw.
 
@@ -108,7 +110,7 @@ def processed_ms_format(in_name: Union[str, Path]) -> ProcessedNameComponents:
         in_name (Union[str, Path]): The name that needs to be broken down into components
 
     Returns:
-        FormatedNameComponents: A structure container the sbid, field, beam and spw
+        Union[FormatedNameComponents,None': A structure container the sbid, field, beam and spw. None is returned if can not be parsed.
     """
 
     in_name = in_name.name if isinstance(in_name, Path) else in_name

--- a/flint/naming.py
+++ b/flint/naming.py
@@ -101,7 +101,7 @@ class ProcessedNameComponents(NamedTuple):
 
 
 def processed_ms_format(
-    in_name: Union[str, Path]
+    in_name: Union[str, Path],
 ) -> Union[ProcessedNameComponents, None]:
     """Will take a formatted name (i.e. one derived from the flint.naming.create_ms_name)
     and attempt to extract its main components. This includes the SBID, field, beam and spw.

--- a/flint/prefect/common/utils.py
+++ b/flint/prefect/common/utils.py
@@ -84,6 +84,7 @@ def task_archive_sbid(
         science_folder_path (Path): Path that contains the imaged produced
         archive_path (Optional[Path], optional): Location to create and store the tar ball at. If None no tarball is created. Defaults to None.
         copy_path (Optional[Path], optional): Location to copy selected files into. If None no files are copied. Defaults to None.
+        max_round (Optional[int], optional): The last self-calibration round peformed. If provied some files form this round are copied (assuming wsclean imaging). If None, the default file patterns in ArchiveOptions are used. Defaults to None.
 
     Returns:
         Path: The science folder files were copied from
@@ -93,9 +94,14 @@ def task_archive_sbid(
 
     archive_options = ArchiveOptions()
 
+    # TODO: What should this be? Just general new regexs passed through,
+    # or is this fine?
     if max_round:
-        additional_file_patterns = (
-            f".*beam[0-9]+\\.round{max_round}-[0-9]{4}-image\\.fits"
+        updated_file_patterns = tuple(archive_options.tar_file_re_patterns) + (
+            f".*beam[0-9]+\\.round{max_round}-[0-9]{4}-image\\.fits",
+        )
+        archive_options = archive_options.with_options(
+            tar_file_re_patterns=updated_file_patterns
         )
 
     if archive_path:

--- a/flint/prefect/common/utils.py
+++ b/flint/prefect/common/utils.py
@@ -76,6 +76,7 @@ def task_archive_sbid(
     science_folder_path: Path,
     archive_path: Optional[Path] = None,
     copy_path: Optional[Path] = None,
+    max_round: Optional[int] = None,
 ) -> Path:
     """Create a tarbal of files, or copy files, from a processing folder.
 
@@ -91,6 +92,12 @@ def task_archive_sbid(
     sbid = get_sbid_from_path(path=science_folder_path)
 
     archive_options = ArchiveOptions()
+
+    if max_round:
+        additional_file_patterns = (
+            f".*beam[0-9]+\\.round{max_round}-[0-9]{4}-image\\.fits"
+        )
+
     if archive_path:
         tar_file_name = add_timestamp_to_path(Path(archive_path) / f"SB{sbid}.tar")
         create_sbid_tar_archive(

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -382,7 +382,7 @@ def process_science_fields(
             science_folder_path=output_split_science_path,
             archive_path=field_options.sbid_archive_path,
             copy_path=field_options.sbid_copy_path,
-            max_round=field_options.rounds if field_options.rounds else None
+            max_round=field_options.rounds if field_options.rounds else None,
             wait_for=archive_wait_for,
         )
 

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -382,6 +382,7 @@ def process_science_fields(
             science_folder_path=output_split_science_path,
             archive_path=field_options.sbid_archive_path,
             copy_path=field_options.sbid_copy_path,
+            max_round=field_options.rounds if field_options.rounds else None
             wait_for=archive_wait_for,
         )
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -15,7 +15,7 @@ from flint.archive import (
     tar_files_into,
 )
 
-FILES = [f"some_file_{a:02d}-image.fits" for a in range(36)] + [
+FILES = [f"some_file_{a:02d}-MFS-image.fits" for a in range(36)] + [
     f"a_validation.{ext}" for ext in ("png", "jpeg", "pdf")
 ]
 
@@ -151,3 +151,17 @@ def test_create_sbid_archive(glob_files):
     )
 
     assert tarfile.is_tarfile(tar_out_path)
+
+
+def test_archive_new_tar_patterns():
+    """Some sanity checks around this archive options tuple updating"""
+    archive_options = ArchiveOptions()
+    before_count = len(archive_options.tar_file_re_patterns)
+
+    additional_file_patterns = (r".*beam[0-9]+\.round4-[0-9]{4}-image\.fits",)
+    new_patterns = archive_options.tar_file_re_patterns + additional_file_patterns
+
+    new_archive_options = archive_options.with_options(
+        tar_file_re_patterns=new_patterns
+    )
+    assert len(new_archive_options.tar_file_re_patterns) == before_count + 1

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -110,6 +110,9 @@ def test_archive_parser(glob_files):
     assert isinstance(args.base_path, Path)
     assert args.base_path == example_path
 
+    args = parser.parse_args(r"list --file-patterns '.*linmos.*' '.*MFS.*'".split())
+    assert len(args.file_patterns) == 2
+
     example_path = Path(base_dir)
     args = parser.parse_args(
         f"list --base-path {str(example_path)} --file-patterns *pdf".split()

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -118,6 +118,10 @@ def test_archive_parser(glob_files):
     assert args.base_path == example_path
     assert args.file_patterns == ["*pdf"]
 
+    cmd = r"create --tar-file-patterns '.*linmos.*' '.*MFS.*' '.*beam[0-9]+\.round4-????-image\.fits' --base-path 39420 test_archive_tarball/39420.tar"
+    args = parser.parse_args(cmd.split())
+    assert len(args.tar_file_patterns) == 3
+
 
 def test_tar_ball_files(temp_files):
     """Ensure that the tarballing works"""

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -103,7 +103,7 @@ def test_archive_parser(glob_files):
     args = parser.parse_args("list".split())
 
     assert isinstance(args.base_path, Path)
-    assert args.file_globs == DEFAULT_TAR_RE_PATTERNS
+    assert args.file_patterns == DEFAULT_TAR_RE_PATTERNS
 
     example_path = Path("this/no/exist")
     args = parser.parse_args(f"list --base-path {str(example_path)}".split())
@@ -112,11 +112,11 @@ def test_archive_parser(glob_files):
 
     example_path = Path(base_dir)
     args = parser.parse_args(
-        f"list --base-path {str(example_path)} --file-globs *pdf".split()
+        f"list --base-path {str(example_path)} --file-patterns *pdf".split()
     )
     assert isinstance(args.base_path, Path)
     assert args.base_path == example_path
-    assert args.file_globs == ["*pdf"]
+    assert args.file_patterns == ["*pdf"]
 
 
 def test_tar_ball_files(temp_files):

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from flint.archive import (
-    DEFAULT_GLOB_EXPRESSIONS,
+    DEFAULT_TAR_RE_PATTERNS,
     ArchiveOptions,
     copy_files_into,
     create_sbid_tar_archive,
@@ -38,7 +38,7 @@ def temp_files(glob_files):
     archive_options = ArchiveOptions()
 
     resolved = resolve_glob_expressions(
-        base_path=base_dir, file_globs=archive_options.file_globs
+        base_path=base_dir, file_re_patterns=archive_options.tar_file_re_patterns
     )
 
     return (base_dir, resolved)
@@ -63,10 +63,10 @@ def test_glob_expressions(glob_files):
     base_dir, files = glob_files
 
     archive_options = ArchiveOptions()
-    assert len(archive_options.file_globs) > 0
+    assert len(archive_options.tar_file_re_patterns) > 0
 
     resolved = resolve_glob_expressions(
-        base_path=base_dir, file_globs=archive_options.file_globs
+        base_path=base_dir, file_re_patterns=archive_options.tar_file_re_patterns
     )
 
     assert all([isinstance(p, Path) for p in resolved])
@@ -77,9 +77,9 @@ def test_glob_expressions_uniq(glob_files):
     """Make sure that the uniqueness is correct"""
     base_dir, files = glob_files
 
-    archive_options = ArchiveOptions(file_globs=(".*png", ".*png"))
+    archive_options = ArchiveOptions(tar_file_re_patterns=(".*png", ".*png"))
     resolved = resolve_glob_expressions(
-        base_path=base_dir, file_globs=archive_options.file_globs
+        base_path=base_dir, file_re_patterns=archive_options.tar_file_re_patterns
     )
     assert len(resolved) == 1
 
@@ -88,9 +88,9 @@ def test_glob_expressions_empty(glob_files):
     """Make sure that the uniqueness is correct"""
     base_dir, files = glob_files
 
-    archive_options = ArchiveOptions(file_globs=(".*doesnotexist",))
+    archive_options = ArchiveOptions(tar_file_re_patterns=(".*doesnotexist",))
     resolved = resolve_glob_expressions(
-        base_path=base_dir, file_globs=archive_options.file_globs
+        base_path=base_dir, file_re_patterns=archive_options.tar_file_re_patterns
     )
     assert len(resolved) == 0
 
@@ -103,7 +103,7 @@ def test_archive_parser(glob_files):
     args = parser.parse_args("list".split())
 
     assert isinstance(args.base_path, Path)
-    assert args.file_globs == DEFAULT_GLOB_EXPRESSIONS
+    assert args.file_globs == DEFAULT_TAR_RE_PATTERNS
 
     example_path = Path("this/no/exist")
     args = parser.parse_args(f"list --base-path {str(example_path)}".split())

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -77,7 +77,7 @@ def test_glob_expressions_uniq(glob_files):
     """Make sure that the uniqueness is correct"""
     base_dir, files = glob_files
 
-    archive_options = ArchiveOptions(file_globs=("*png", "*png"))
+    archive_options = ArchiveOptions(file_globs=(".*png", ".*png"))
     resolved = resolve_glob_expressions(
         base_path=base_dir, file_globs=archive_options.file_globs
     )
@@ -88,7 +88,7 @@ def test_glob_expressions_empty(glob_files):
     """Make sure that the uniqueness is correct"""
     base_dir, files = glob_files
 
-    archive_options = ArchiveOptions(file_globs=("*doesnotexist",))
+    archive_options = ArchiveOptions(file_globs=(".*doesnotexist",))
     resolved = resolve_glob_expressions(
         base_path=base_dir, file_globs=archive_options.file_globs
     )


### PR DESCRIPTION
Use regular expressions instead of globs in the `ArchiveOptions` structure and corresponding functions. These are easier to build complex paths over many smaller individual globs, etc the set operator `{}`, one or more `[0-9]+`. 