### PR TITLE
Boxcar filters for masking

### DIFF
--- a/flint/masking.py
+++ b/flint/masking.py
@@ -239,20 +239,24 @@ def minimum_boxcar_artefact_mask(
     mask = island_mask.copy()
 
     # label each of the islands with a id
-    mask_labels, no_labels = label(island_mask, structure=np.ones((3, 3)))  # type: ignore
+    mask_labels, _ = label(island_mask, structure=np.ones((3, 3)))  # type: ignore
+    uniq_labels = np.unique(mask)
 
     rolling_min = minimum_filter(signal, boxcar_size)
 
     # For each island work out the maximum signal in the island and the minimum signal
     # at the island in the output of the boxcar.
-    island_max = {k: np.max(signal[mask == k]) for k in mask_labels if k != 0}
+    island_max = {k: np.max(signal[mask_labels == k]) for k in uniq_labels if k != 0}
     island_min = {
-        k: np.min(rolling_min[island_mask == k]) for k in mask_labels if k != 0
+        k: np.min(rolling_min[mask_labels == k]) for k in uniq_labels if k != 0
     }
 
     # Nuke the weak ones, mask and report
     eliminate = [
-        k for k in island_max if island_max[k] < np.abs(increase_factor * island_min[k])
+        k
+        for k in island_max
+        if island_max[k] < np.abs(increase_factor * island_min[k])
+        and island_min[k] < 0.0
     ]
     # Walk the plank
     island_mask[np.isin(mask_labels, eliminate)] = False

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -241,6 +241,7 @@ def minimum_boxcar_artefact_mask(
     # label each of the islands with a id
     mask_labels, _ = label(island_mask, structure=np.ones((3, 3)))  # type: ignore
     uniq_labels = np.unique(mask_labels)
+    logger.info(f"Number of unique islands: {len(uniq_labels)}")
 
     rolling_min = minimum_filter(signal, boxcar_size)
 
@@ -269,8 +270,6 @@ def minimum_boxcar_artefact_mask(
     island_mask[np.isin(mask_labels, eliminate)] = False
 
     logger.info(f"Eliminated {len(eliminate)} islands")
-    for idx in eliminate:
-        logger.info(f"Island ID: {idx}, size {np.sum(mask_labels==idx)}")
 
     return mask
 

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -262,6 +262,8 @@ def minimum_boxcar_artefact_mask(
     island_mask[np.isin(mask_labels, eliminate)] = False
 
     logger.info(f"Eliminated {len(eliminate)} islands")
+    for idx in eliminate:
+        logger.info(f"Island ID: {idx}, size {np.sum(mask_labels==idx)}")
 
     return mask
 

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -240,7 +240,7 @@ def minimum_boxcar_artefact_mask(
 
     # label each of the islands with a id
     mask_labels, _ = label(island_mask, structure=np.ones((3, 3)))  # type: ignore
-    uniq_labels = np.unique(mask)
+    uniq_labels = np.unique(mask_labels)
 
     rolling_min = minimum_filter(signal, boxcar_size)
 

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -267,7 +267,7 @@ def minimum_boxcar_artefact_mask(
         and island_min[k] < 0.0
     ]
     # Walk the plank
-    island_mask[np.isin(mask_labels, eliminate)] = False
+    mask[np.isin(mask_labels, eliminate)] = False
 
     logger.info(f"Eliminated {len(eliminate)} islands")
 

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -57,7 +57,7 @@ class MaskingOptions(NamedTuple):
     """Use the boxcar minimum threshold to compare to remove artefacts"""
     minimum_boxcar_size: int = 100
     """Size of the boxcar filter"""
-    minimum_boxcar_factor: float = 1.2
+    minimum_boxcar_increase_factor: float = 1.2
     """The factor used to construct minimum positive signal threshold for an island """
 
     def with_options(self, **kwargs) -> MaskingOptions:
@@ -416,6 +416,14 @@ def reverse_negative_flood_fill(
         iterations=1000,
         structure=np.ones((3, 3)),
     )
+
+    if masking_options.minimum_boxcar:
+        positive_dilated_mask = minimum_boxcar_artefact_mask(
+            signal=signal,
+            island_mask=positive_dilated_mask,
+            boxcar_size=masking_options.minimum_boxcar_size,
+            increase_factor=masking_options.minimum_boxcar_increase_factor,
+        )
 
     negative_dilated_mask = None
     if masking_options.suppress_artefacts:

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -132,7 +132,7 @@ def _get_signal_image(
     if all([item is None for item in (image, background, rms, signal)]):
         raise ValueError("No input maps have been provided. ")
 
-    if signal is None:
+    if signal is None and image and rms:
         if background is None:
             logger.info("No background supplied, assuming zeros. ")
             background = np.zeros_like(image)
@@ -434,7 +434,7 @@ def reverse_negative_flood_fill(
         image=image, rms=rms, background=background, signal=signal
     )
 
-    if masking_options.flood_fill_use_mbc:
+    if masking_options.flood_fill_use_mbc and image:
         positive_mask = minimum_absolute_clip(
             image=image, increase_factor=masking_options.flood_fill_positive_seed_clip
         )
@@ -560,6 +560,7 @@ def create_snr_mask_from_fits(
         # TODO: This function should really just accept a MaskingOptions directly
         mask_data = reverse_negative_flood_fill(
             signal=np.squeeze(signal_data),
+            image=np.squeeze(fits.getdata(fits_image_path)),
             masking_options=masking_options,
             pixels_per_beam=pixels_per_beam,
         )

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -246,10 +246,17 @@ def minimum_boxcar_artefact_mask(
 
     # For each island work out the maximum signal in the island and the minimum signal
     # at the island in the output of the boxcar.
-    island_max = {k: np.max(signal[mask_labels == k]) for k in uniq_labels if k != 0}
-    island_min = {
-        k: np.min(rolling_min[mask_labels == k]) for k in uniq_labels if k != 0
-    }
+    island_min, island_max = {}, {}
+    for island_id in uniq_labels:
+        if island_id == 0:
+            continue
+
+        # compute the mask once. These could be a dixt comprehension
+        # but then this mask is computed twice
+        island_id_mask = mask_labels == island_id
+
+        island_max[island_id] = np.max(signal[island_id_mask])
+        island_min[island_id] = np.min(rolling_min[island_id_mask])
 
     # Nuke the weak ones, mask and report
     eliminate = [

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -209,7 +209,7 @@ def minimum_boxcar_artefact_mask(
     signal: np.ndarray,
     island_mask: np.ndarray,
     boxcar_size: int,
-    increase_factor: float = 1.2,
+    increase_factor: float = 2.0,
 ) -> np.ndarray:
     """Attempt to remove islands from a potential clean mask by
     examining surronding pixels. A boxcar is applied to find the
@@ -225,7 +225,7 @@ def minimum_boxcar_artefact_mask(
         signal (np.ndarray): The input signl to use
         island_mask (np.ndarray): The current island mask derived by other methods
         boxcar_size (int): Size of the minimum boxcar size
-        increase_factor (float, optional): Factor to increase the minimum signal by. Defaults to 1.2.
+        increase_factor (float, optional): Factor to increase the minimum signal by. Defaults to 2.0.
 
     Returns:
         np.ndarray: _description_

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -204,6 +204,7 @@ def grow_low_snr_mask(
     return low_snr_mask
 
 
+# TODO> Allow box car size to be scaled in proportion to beam size
 def minimum_boxcar_artefact_mask(
     signal: np.ndarray,
     island_mask: np.ndarray,

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -132,7 +132,7 @@ def _get_signal_image(
     if all([item is None for item in (image, background, rms, signal)]):
         raise ValueError("No input maps have been provided. ")
 
-    if signal is None and image and rms:
+    if signal is None and image is not None and rms is not None:
         if background is None:
             logger.info("No background supplied, assuming zeros. ")
             background = np.zeros_like(image)
@@ -434,7 +434,7 @@ def reverse_negative_flood_fill(
         image=image, rms=rms, background=background, signal=signal
     )
 
-    if masking_options.flood_fill_use_mbc and image:
+    if masking_options.flood_fill_use_mbc and image is not None:
         positive_mask = minimum_absolute_clip(
             image=image, increase_factor=masking_options.flood_fill_positive_seed_clip
         )

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -1,3 +1,4 @@
+from ast import increment_lineno
 from pathlib import Path
 
 import numpy as np
@@ -28,12 +29,31 @@ def test_minimum_boxcar_artefact():
         signal=img, island_mask=img_mask, boxcar_size=10
     )
     assert np.all(img_mask == out_mask)
+    assert img_mask is not out_mask
 
     img[41:45, 30:40] = -20
     out_mask = minimum_boxcar_artefact_mask(
         signal=img, island_mask=img_mask, boxcar_size=10
     )
     assert not np.all(img_mask == out_mask)
+
+
+def test_minimum_boxcar_artefact_blanked():
+    """See if the minimum box care artefact suppressor can suppress the
+    bright artefact when a bright negative artefact
+    """
+    img = np.zeros((SHAPE))
+
+    img[30:40, 30:40] = 10
+    img[41:45, 30:40] = -20
+
+    img_mask = img > 5
+
+    out_mask = minimum_boxcar_artefact_mask(
+        signal=img, island_mask=img_mask, boxcar_size=10, increase_factor=1000
+    )
+    assert out_mask is not img_mask
+    assert np.all(out_mask[30:40, 30:40] == False)  # noqa
 
 
 def test_minimum_boxcar_large_bright_island():

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -8,10 +8,47 @@ from flint.masking import (
     MaskingOptions,
     _verify_set_positive_seed_clip,
     create_snr_mask_from_fits,
+    minimum_boxcar_artefact_mask,
 )
 from flint.naming import FITSMaskNames
 
 SHAPE = (100, 100)
+
+
+def test_minimum_boxcar_artefact():
+    """See if the minimum box care artefact suppressor can suppress the
+    bright artefact when a bright negative artefact
+    """
+    img = np.zeros((SHAPE))
+
+    img[30:40, 30:40] = 10
+    img_mask = img > 5
+
+    out_mask = minimum_boxcar_artefact_mask(
+        signal=img, island_mask=img_mask, boxcar_size=10
+    )
+    assert np.all(img_mask == out_mask)
+
+    img[41:45, 30:40] = -20
+    out_mask = minimum_boxcar_artefact_mask(
+        signal=img, island_mask=img_mask, boxcar_size=10
+    )
+    assert not np.all(img_mask == out_mask)
+
+
+def test_minimum_boxcar_large_bright_island():
+    """This one checks to make sure that if the boxcar is smaller than
+    a positive islane that the island is not the island_min
+    """
+
+    img = np.zeros(SHAPE)
+    img[30:40, 30:40] = 10
+    img_mask = img > 5
+
+    out_mask = minimum_boxcar_artefact_mask(
+        signal=img, island_mask=img_mask, boxcar_size=2
+    )
+    assert np.all(img_mask == out_mask)
 
 
 @pytest.fixture

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -1,4 +1,3 @@
-from ast import increment_lineno
 from pathlib import Path
 
 import numpy as np


### PR DESCRIPTION
Some functionality around better masking constraints used to help refine a robust clean mask. 

I think the best method so far is this minimum absolute boxcar clip. There are some other operational modes, but this one seems to be the most simple and effective. 

They is going to have to be a little bit of more work in orfer to refine the API into it, and to further the framework in include a non-zero background term. 