### PR TITLE
Skip mask and selfcal during imaging rounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+# Dev
+- added in skip rounds for masking and selfcal
+
 ## 0.2.4
 
 - Added new masking modes

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -90,10 +90,9 @@ def consider_beam_mask_round(
     Returns:
         bool: _description_
     """
-    if mask_rounds is None:
-        return False
+    logger.info(f"Considering {current_round=} {mask_rounds=}")
 
-    return (
+    return mask_rounds is not None and (
         (isinstance(mask_rounds, str) and mask_rounds.lower() == "all")
         or (isinstance(mask_rounds, int) and current_round > mask_rounds)
         or (isinstance(mask_rounds, Iterable) and current_round in mask_rounds)  # type: ignore

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -96,6 +96,7 @@ def consider_beam_mask_round(
     """
     logger.info(f"Considering {current_round=} {mask_rounds=} {allow_beam_masks=}")
 
+    # The return below was getting silly to meantally parse
     if not allow_beam_masks:
         return False
 

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -5,10 +5,10 @@ thought being towards FITS images.
 from __future__ import annotations
 
 from argparse import ArgumentParser
+from collections import Iterable
 from pathlib import Path
-from typing import NamedTuple, Optional
+from typing import NamedTuple, Optional, Collection, Union
 
-from matplotlib.dviread import Box
 import numpy as np
 from astropy.io import fits
 from astropy.wcs import WCS
@@ -71,6 +71,33 @@ class MaskingOptions(NamedTuple):
         _dict.update(**kwargs)
 
         return MaskingOptions(**_dict)
+
+
+def consider_beam_mask_round(
+    current_round: int, mask_rounds: Union[str, Collection[int], int]
+) -> bool:
+    """Evaluate whether a self-calibration round should have a beam clean mask
+    constructed. Rules are:
+
+    - if `mask_rounds` is a string and is "all", all rounds will have a beam mask
+    - if 'mask_rounds' is a single integer, so long as `current_round` is larger it will have a beam mask
+    - if `mask_rounds` is iterable and contains `current_round` it will have a beam mask
+
+    Args:
+        current_round (int): The current self-calibration round that is being performed
+        mask_rounds (Union[str, Collection[int], int]): The rules to consider whether a beam mask is needed
+
+    Returns:
+        bool: _description_
+    """
+    if mask_rounds is None:
+        return False
+
+    return (
+        (isinstance(mask_rounds, str) and mask_rounds.lower() == "all")
+        or (isinstance(mask_rounds, int) and current_round > mask_rounds)
+        or (isinstance(mask_rounds, Iterable) and current_round in mask_rounds)  # type: ignore
+    )
 
 
 def extract_beam_mask_from_mosaic(
@@ -364,7 +391,9 @@ def minimum_absolute_clip(
     logger.info(f"Minimum absolute clip, {increase_factor=} {box_size=}")
     rolling_box_min = minimum_filter(image, box_size)
 
-    image_mask = image > (increase_factor * np.abs(rolling_box_min))
+    image_mask = (image > (increase_factor * np.abs(rolling_box_min))) | (
+        (image > 0.0) & (rolling_box_min > 0.0)
+    )
 
     return image_mask
 

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from argparse import ArgumentParser
 from collections import Iterable
 from pathlib import Path
-from typing import NamedTuple, Optional, Collection, Union
+from typing import Collection, NamedTuple, Optional, Union
 
 import numpy as np
 from astropy.io import fits

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -74,7 +74,9 @@ class MaskingOptions(NamedTuple):
 
 
 def consider_beam_mask_round(
-    current_round: int, mask_rounds: Union[str, Collection[int], int]
+    current_round: int,
+    mask_rounds: Union[str, Collection[int], int],
+    allow_beam_masks: bool = True,
 ) -> bool:
     """Evaluate whether a self-calibration round should have a beam clean mask
     constructed. Rules are:
@@ -82,15 +84,20 @@ def consider_beam_mask_round(
     - if `mask_rounds` is a string and is "all", all rounds will have a beam mask
     - if 'mask_rounds' is a single integer, so long as `current_round` is larger it will have a beam mask
     - if `mask_rounds` is iterable and contains `current_round` it will have a beam mask
+    - if `allow_beam_masks` is False a False is returned. Otherwise options above are considered.
 
     Args:
         current_round (int): The current self-calibration round that is being performed
         mask_rounds (Union[str, Collection[int], int]): The rules to consider whether a beam mask is needed
+        allow_beam_masks (bool, optional): A global allow / deny. This should be `True` for other rules to be considered. Defaults to True.
 
     Returns:
-        bool: _description_
+        bool: Whether per beam mask should be performed
     """
-    logger.info(f"Considering {current_round=} {mask_rounds=}")
+    logger.info(f"Considering {current_round=} {mask_rounds=} {allow_beam_masks=}")
+
+    if not allow_beam_masks:
+        return False
 
     return mask_rounds is not None and (
         (isinstance(mask_rounds, str) and mask_rounds.lower() == "all")

--- a/flint/naming.py
+++ b/flint/naming.py
@@ -3,11 +3,42 @@ products.
 """
 
 import re
+
 from datetime import datetime
 from pathlib import Path
 from typing import Any, List, NamedTuple, Optional, Union
 
 from flint.logging import logger
+
+
+def get_selfcal_ms_name(in_ms_path: Path, round: int = 1) -> Path:
+    """Create the new output MS path that will be used for self-calibration. The
+    output measurement set path will include a roundN.ms suffix, where N is the
+    round. If such a suffic already exists from an earlier self-calibration round,
+    it will be removed and replaced.
+
+    Args:
+        in_ms_path (Path): The measurement set that will go through self-calibration
+        round (int, optional): The self-calibration round number that is currently being used. Defaults to 1.
+
+    Returns:
+        Path: Output measurement set path to use
+    """
+    res = re.search("\\.round[0-9]+.ms", str(in_ms_path.name))
+    if res:
+        logger.info("Detected a previous round of self-calibration. ")
+        span = res.span()
+        name_str = str(in_ms_path.name)
+        name = f"{name_str[:span[0]]}.round{round}.ms"
+    else:
+        name = f"{str(in_ms_path.stem)}.round{round}.ms"
+    out_ms_path = in_ms_path.parent / name
+
+    assert (
+        in_ms_path != out_ms_path
+    ), f"{in_ms_path=} and {out_ms_path=} match. Something went wrong when creating new self-cal name. "
+
+    return out_ms_path
 
 
 def add_timestamp_to_path(

--- a/flint/naming.py
+++ b/flint/naming.py
@@ -3,7 +3,6 @@ products.
 """
 
 import re
-
 from datetime import datetime
 from pathlib import Path
 from typing import Any, List, NamedTuple, Optional, Union

--- a/flint/options.py
+++ b/flint/options.py
@@ -3,7 +3,7 @@ set of flint processing related options.
 """
 
 from pathlib import Path
-from typing import NamedTuple, Optional, Union, Collection
+from typing import NamedTuple, Optional, Union, List
 
 
 class BandpassOptions(NamedTuple):
@@ -96,7 +96,7 @@ class FieldOptions(NamedTuple):
     """Whether to apply (or search for solutions with) a bandpass smoothing operation applied"""
     use_beam_masks: bool = True
     """Construct beam masks from MFS images to use for the next round of imaging. """
-    use_beam_mask_rounds: Union[str, Collection[int], int] = 1
+    use_beam_mask_rounds: Union[str, List[int], int] = 1
     """If `use_beam_masks` is True, this sets which rounds should have a mask applied"""
     imaging_strategy: Optional[Path] = None
     """Path to a FLINT imaging yaml file that contains settings to use throughout imaging"""

--- a/flint/options.py
+++ b/flint/options.py
@@ -3,7 +3,7 @@ set of flint processing related options.
 """
 
 from pathlib import Path
-from typing import NamedTuple, Optional
+from typing import NamedTuple, Optional, Union, Collection
 
 
 class BandpassOptions(NamedTuple):
@@ -96,8 +96,8 @@ class FieldOptions(NamedTuple):
     """Whether to apply (or search for solutions with) a bandpass smoothing operation applied"""
     use_beam_masks: bool = True
     """Construct beam masks from MFS images to use for the next round of imaging. """
-    use_beam_masks_from: int = 2
-    """If `use_beam_masks` is True, start using them from this round of self-calibration"""
+    use_beam_mask_rounds: Union[str, Collection[int], int] = 1
+    """If `use_beam_masks` is True, this sets which rounds should have a mask applied"""
     imaging_strategy: Optional[Path] = None
     """Path to a FLINT imaging yaml file that contains settings to use throughout imaging"""
     sbid_archive_path: Optional[Path] = None

--- a/flint/options.py
+++ b/flint/options.py
@@ -71,7 +71,9 @@ class FieldOptions(NamedTuple):
     holofile: Optional[Path] = None
     """Path to the holography FITS cube that will be used when co-adding beams"""
     rounds: int = 2
-    """Number of required rouds of self-calibration to perform"""
+    """Number of required rouds of self-calibration and imaging to perform"""
+    skip_selfcal_on_rounds: Optional[List[int]] = None
+    """Do not perform the derive and apply self-calibration solutions on these rounds"""
     zip_ms: bool = False
     """Whether to zip measurement sets once they are no longer required"""
     run_aegean: bool = False
@@ -82,8 +84,6 @@ class FieldOptions(NamedTuple):
     """Whether to skip the imaging process (including self-calibration)"""
     reference_catalogue_directory: Optional[Path] = None
     """Path to the directory container the refernce catalogues, used to generate valiation plots"""
-    butterworth_filter: bool = False
-    """Whether a Butterworth filter should be used when constructing the clean mask"""
     linmos_residuals: bool = False
     """Linmos the cleaning residuals together into a field image"""
     beam_cutoff: float = 150

--- a/flint/options.py
+++ b/flint/options.py
@@ -3,7 +3,7 @@ set of flint processing related options.
 """
 
 from pathlib import Path
-from typing import NamedTuple, Optional, Union, List
+from typing import List, NamedTuple, Optional, Union
 
 
 class BandpassOptions(NamedTuple):

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -219,7 +219,7 @@ def task_gaincal_applycal_ms(
         round (int): Counter indication which self-calibration round is being performed. A name is included based on this.
         update_gain_cal_options (Optional[Dict[str, Any]], optional): Options used to overwrite the default ``gaincal`` options. Defaults to None.
         archive_input_ms (bool, optional): If True the input measurement set is zipped. Defaults to False.
-        skip_selfcal (bool, optional): Should this self-cal be skipped. If `True`, the input MS is symlinked with the appropriate new name and returned.
+        skip_selfcal (bool, optional): Should this self-cal be skipped. If `True`, the a new MS is created but not calibrated the appropriate new name and returned.
 
     Raises:
         ValueError: Raised when a ``.ms`` attribute can not be obtained
@@ -241,6 +241,7 @@ def task_gaincal_applycal_ms(
         round=round,
         update_gain_cal_options=update_gain_cal_options,
         archive_input_ms=archive_input_ms,
+        skip_selfcal=skip_selfcal,
     )
 
 

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -210,6 +210,7 @@ def task_gaincal_applycal_ms(
     round: int,
     update_gain_cal_options: Optional[Dict[str, Any]] = None,
     archive_input_ms: bool = False,
+    skip_selfcal: bool = False,
 ) -> MS:
     """Perform self-calibration using CASA gaincal and applycal.
 
@@ -218,6 +219,7 @@ def task_gaincal_applycal_ms(
         round (int): Counter indication which self-calibration round is being performed. A name is included based on this.
         update_gain_cal_options (Optional[Dict[str, Any]], optional): Options used to overwrite the default ``gaincal`` options. Defaults to None.
         archive_input_ms (bool, optional): If True the input measurement set is zipped. Defaults to False.
+        skip_selfcal (bool, optional): Should this self-cal be skipped. If `True`, the input MS is symlinked with the appropriate new name and returned.
 
     Raises:
         ValueError: Raised when a ``.ms`` attribute can not be obtained

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -582,7 +582,7 @@ def get_parser() -> ArgumentParser:
     )
     beam_mask_options.add_argument(
         "--use-beam-masks-from",
-        default=None,
+        default=1,
         type=int,
         help="If --use-beam-masks is provided, this option specifies from which round of self-calibration the masking operation will be used onwards from. ",
     )

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -636,7 +636,7 @@ def cli() -> None:
             args.use_beam_mask_rounds
             if args.use_beam_mask_rounds
             else args.use_beam_masks_from
-        ),
+        ),  # defaults value of args.use_beam_masks_from is 1
         imaging_strategy=args.imaging_strategy,
         sbid_archive_path=args.sbid_archive_path,
         sbid_copy_path=args.sbid_copy_path,

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -282,9 +282,10 @@ def process_science_fields(
             )
 
             fits_beam_masks = None
-            if field_options.use_beam_masks and consider_beam_mask_round(
+            if consider_beam_mask_round(
                 current_round=current_round,
                 mask_rounds=field_options.use_beam_mask_rounds,
+                allow_beam_masks=field_options.use_beam_masks,
             ):
                 masking_options = get_options_from_strategy(
                     strategy=strategy, mode="masking", round=current_round

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -281,6 +281,7 @@ def process_science_fields(
                 ],  # To make sure field summary is created with unzipped MSs
             )
 
+            fits_beam_masks = None
             if field_options.use_beam_masks and consider_beam_mask_round(
                 current_round=current_round,
                 mask_rounds=field_options.use_beam_mask_rounds,

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -272,11 +272,17 @@ def process_science_fields(
                 strategy=strategy, mode="wsclean", round=current_round
             )
 
+            skip_gaincal_current_round = consider_skip_selfcal_on_round(
+                current_round=current_round,
+                skip_selfcal_on_rounds=field_options.skip_selfcal_on_rounds,
+            )
+
             cal_mss = task_gaincal_applycal_ms.map(
                 wsclean_cmd=wsclean_cmds,
                 round=current_round,
                 update_gain_cal_options=unmapped(gain_cal_options),
                 archive_input_ms=field_options.zip_ms,
+                skip_selfcal=skip_gaincal_current_round,
                 wait_for=[
                     field_summary
                 ],  # To make sure field summary is created with unzipped MSs
@@ -504,7 +510,7 @@ def get_parser() -> ArgumentParser:
         help="The number of selfcalibration rounds to perfrom. ",
     )
     parser.add_argument(
-        "--skip_selfcal_on_rounds",
+        "--skip-selfcal-on-rounds",
         type=int,
         nargs="+",
         default=None,

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -50,6 +50,7 @@ from flint.prefect.common.utils import (
     task_update_field_summary,
     task_update_with_options,
 )
+from flint.selfcal.utils import consider_skip_selfcal_on_round
 
 
 @flow(name="Flint Continuum Pipeline")
@@ -503,6 +504,13 @@ def get_parser() -> ArgumentParser:
         help="The number of selfcalibration rounds to perfrom. ",
     )
     parser.add_argument(
+        "--skip_selfcal_on_rounds",
+        type=int,
+        nargs="+",
+        default=None,
+        help="Do not perform the derive and apply self-calibration solutions on these rounds",
+    )
+    parser.add_argument(
         "--zip-ms",
         action="store_true",
         help="Zip up measurement sets as imaging and self-calibration is carried out.",
@@ -607,6 +615,7 @@ def cli() -> None:
         yandasoft_container=args.yandasoft_container,
         potato_container=args.potato_container,
         rounds=args.selfcal_rounds,
+        skip_selfcal_on_rounds=args.skip_selfcal_on_rounds,
         zip_ms=args.zip_ms,
         run_aegean=args.run_aegean,
         aegean_container=args.aegean_container,

--- a/flint/selfcal/casa.py
+++ b/flint/selfcal/casa.py
@@ -9,7 +9,6 @@ from argparse import ArgumentParser
 from pathlib import Path
 from shutil import copytree
 from typing import Any, Dict, NamedTuple, Optional
-from unittest import skip
 
 from casacore.tables import table
 from casatasks import applycal, cvel, gaincal, mstransform

--- a/flint/selfcal/casa.py
+++ b/flint/selfcal/casa.py
@@ -242,6 +242,10 @@ def gaincal_applycal_ms(
     # Pirates like easy things though.
     cal_ms = copy_and_clean_ms_casagain(ms=ms, round=round)
 
+    # Archive straight after copying incase we skip the gaincal and return
+    if archive_input_ms:
+        zip_folder(in_path=ms.path)
+
     # No need to do work me, hardy
     if skip_selfcal:
         logger.info(f"{skip_selfcal=}, not calibrating the MS. ")
@@ -301,9 +305,6 @@ def gaincal_applycal_ms(
         # At the time of writing merge_spws_in_ms returns the ms_path=,
         # but this pirate trusts no one.
         cal_ms = cal_ms.with_options(path=cal_ms_path)
-
-    if archive_input_ms:
-        zip_folder(in_path=ms.path)
 
     return cal_ms.with_options(column="CORRECTED_DATA")
 

--- a/flint/selfcal/utils.py
+++ b/flint/selfcal/utils.py
@@ -3,9 +3,6 @@ across different packages.
 """
 
 from typing import List, Union
-from unittest import skip
-
-from flint.logging import logger
 
 
 def consider_skip_selfcal_on_round(

--- a/flint/selfcal/utils.py
+++ b/flint/selfcal/utils.py
@@ -2,7 +2,7 @@
 across different packages.
 """
 
-from typing import Union, List
+from typing import List, Union
 from unittest import skip
 
 from flint.logging import logger

--- a/flint/selfcal/utils.py
+++ b/flint/selfcal/utils.py
@@ -1,0 +1,39 @@
+"""Gemeral help functions that could be used for self-calibration
+across different packages.
+"""
+
+from typing import Union, List
+from unittest import skip
+
+from flint.logging import logger
+
+
+def consider_skip_selfcal_on_round(
+    current_round: int, skip_selfcal_on_rounds: Union[int, List[int], None]
+) -> bool:
+    """Consider whether the self-calibration process (derive and applying solutions)
+    should be skipped on a particular imaging round.
+
+    Should `current_round` be in `skip_selfcal_on_round` then the self-calibration
+    should be skipped and a `True` is returned.
+
+    Args:
+        current_round (int): The current imaging round being considered
+        skip_selfcal_on_rounds (Union[int, List[int], None]): The set of rounds that should be considerede for skipping. If None a False is returned.
+
+    Returns:
+        bool: Whether the round is skipped (True) or performed (False)
+    """
+
+    # Consider whether this is unset, in which case all rounds should be self-cal
+    if skip_selfcal_on_rounds is None:
+        return False
+
+    # For sanity consider a single int case
+    skip_selfcal_on_rounds = (
+        skip_selfcal_on_rounds
+        if isinstance(skip_selfcal_on_rounds, list)
+        else [skip_selfcal_on_rounds]
+    )
+
+    return current_round in skip_selfcal_on_rounds

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -19,7 +19,9 @@ SHAPE = (100, 100)
 def test_consider_beam_masking_round():
     """Test to ensure the beam mask consideration log is correct"""
     lower = ("all", "ALL", "aLl")
-    states = (consider_beam_mask_round(current_round=1, mask_rounds=l) for l in lower)
+    states = (
+        consider_beam_mask_round(current_round=1, mask_rounds=low) for low in lower
+    )
 
     assert all(states)
 

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -7,9 +7,9 @@ from astropy.io import fits
 from flint.masking import (
     MaskingOptions,
     _verify_set_positive_seed_clip,
+    consider_beam_mask_round,
     create_snr_mask_from_fits,
     minimum_boxcar_artefact_mask,
-    consider_beam_mask_round,
 )
 from flint.naming import FITSMaskNames
 

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -31,6 +31,13 @@ def test_consider_beam_masking_round():
 
     assert not consider_beam_mask_round(current_round=3, mask_rounds=None)
 
+    assert not consider_beam_mask_round(
+        current_round=3, mask_rounds=1, allow_beam_masks=False
+    )
+    assert consider_beam_mask_round(
+        current_round=3, mask_rounds=1, allow_beam_masks=True
+    )
+
 
 def test_minimum_boxcar_artefact():
     """See if the minimum box care artefact suppressor can suppress the

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -9,10 +9,27 @@ from flint.masking import (
     _verify_set_positive_seed_clip,
     create_snr_mask_from_fits,
     minimum_boxcar_artefact_mask,
+    consider_beam_mask_round,
 )
 from flint.naming import FITSMaskNames
 
 SHAPE = (100, 100)
+
+
+def test_consider_beam_masking_round():
+    """Test to ensure the beam mask consideration log is correct"""
+    lower = ("all", "ALL", "aLl")
+    states = (consider_beam_mask_round(current_round=1, mask_rounds=l) for l in lower)
+
+    assert all(states)
+
+    assert consider_beam_mask_round(current_round=3, mask_rounds=1)
+    assert not consider_beam_mask_round(current_round=0, mask_rounds=1)
+
+    assert consider_beam_mask_round(current_round=3, mask_rounds=(1, 2, 3, 4, 5))
+    assert not consider_beam_mask_round(current_round=3, mask_rounds=(1, 2, 4, 5))
+
+    assert not consider_beam_mask_round(current_round=3, mask_rounds=None)
 
 
 def test_minimum_boxcar_artefact():

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -15,9 +15,34 @@ from flint.naming import (
     get_aocalibrate_output_path,
     get_potato_output_base_path,
     get_sbid_from_path,
+    get_selfcal_ms_name,
     processed_ms_format,
     raw_ms_format,
 )
+
+
+def test_self_cal_name():
+    """Checks around where the self-calibration naming is working, and the
+    correct slicing"""
+
+    ms = Path("SB12349.RACS_1234+45.ms")
+    e_ms = Path("SB12349.RACS_1234+45.round1.ms")
+    out_ms = get_selfcal_ms_name(in_ms_path=ms, round=1)
+    assert out_ms == e_ms
+
+    ms = Path("SB12349.RACS_1234+45.round1.ms")
+    e_ms = Path("SB12349.RACS_1234+45.round2.ms")
+    out_ms = get_selfcal_ms_name(in_ms_path=ms, round=2)
+    assert out_ms == e_ms
+
+    ms = Path(
+        "/some/other/directory/SB12349.RACS_1234+45.verrrrryyylonnnnnnnhhhhh.round1.ms"
+    )
+    e_ms = Path(
+        "/some/other/directory/SB12349.RACS_1234+45.verrrrryyylonnnnnnnhhhhh.round2.ms"
+    )
+    out_ms = get_selfcal_ms_name(in_ms_path=ms, round=2)
+    assert out_ms == e_ms
 
 
 def test_potato_output_name():

--- a/tests/test_selfcal_utils.py
+++ b/tests/test_selfcal_utils.py
@@ -1,0 +1,20 @@
+"""Tests around utility helper functions for self-calibration"""
+
+from flint.selfcal.utils import consider_skip_selfcal_on_round
+
+
+def test_consider_skip_selfcal():
+    """Ensure that the skipping behaves as expected"""
+
+    # None here means nothing should be skipped
+    res = consider_skip_selfcal_on_round(current_round=1, skip_selfcal_on_rounds=None)
+
+    assert not res
+
+    res = consider_skip_selfcal_on_round(current_round=1, skip_selfcal_on_rounds=[2, 3])
+    assert not res
+
+    res = consider_skip_selfcal_on_round(current_round=2, skip_selfcal_on_rounds=[2, 3])
+    assert res
+    res = consider_skip_selfcal_on_round(current_round=2, skip_selfcal_on_rounds=2)
+    assert res


### PR DESCRIPTION
In some discussions, it was suggested to explore a process where we image and self-calibrate using data from long baselines in order to filter out the difficult to deconvolve diffuse emission. Once that is completed, attempt to do a deep multi-scale clean. 

Although the basics of this process were already enabled, what was not available was a way of disabling either masking or self-calibration tasks throughout the self-cal and imaging loop. This attempts to bring some of this in. 

I am not entirely comfortable with the current approach, which exposes some extra CLI options where rounds can be specified as ones to skip (for self-cal) or rounds to create beam masks for (as for masking, which has always been opt-in). Perhaps the better approach is to add this go/no go options to the `Options` classes. But that is sort of in conflict with my eorry of putting too much flow control into what should be pure options. 