### PR TITLE
dded a 02:d formatter for beam field in flint style naming

### DIFF
--- a/flint/naming.py
+++ b/flint/naming.py
@@ -344,7 +344,7 @@ def create_ms_name(
         ms_name_list.append(field)
 
     if format_components:
-        ms_name_list.append(f"beam{format_components.beam}")
+        ms_name_list.append(f"beam{int(format_components.beam):02d}")
         if format_components.spw:
             ms_name_list.append(f"spw{format_components.spw}")
 

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -261,26 +261,26 @@ def test_components_all_beams_spws():
 
 def test_create_ms_name():
     example_path = "/scratch3/gal16b/askap_sbids/39400/2022-04-14_100122_0.ms"
-    expected = "SB39400.beam0.ms"
+    expected = "SB39400.beam00.ms"
     ms_path = create_ms_name(ms_path=example_path)
     assert isinstance(ms_path, str)
     assert ms_path == expected
     assert ms_path.endswith(".ms")
 
     example_path_2 = "/scratch3/gal16b/askap_sbids/39400/2022-04-14_100122_0.ms"
-    expected_2 = "SB39400.RACS_0635-31.beam0.ms"
+    expected_2 = "SB39400.RACS_0635-31.beam00.ms"
     ms_path_2 = create_ms_name(ms_path=example_path_2, field="RACS_0635-31")
     assert isinstance(ms_path_2, str)
     assert ms_path_2 == expected_2
 
     example_path_3 = "/scratch3/gal16b/askap_sbids/39400/2022-04-14_100122_0.ms"
-    expected_3 = "SB1234.RACS_0635-31.beam0.ms"
+    expected_3 = "SB1234.RACS_0635-31.beam00.ms"
     ms_path_3 = create_ms_name(ms_path=example_path_3, sbid=1234, field="RACS_0635-31")
     assert isinstance(ms_path_3, str)
     assert ms_path_3 == expected_3
 
     example_path_4 = "/scratch3/gal16b/askap_sbids/39400/2022-04-14_100122_0_12.ms"
-    expected_4 = "SB1234.RACS_0635-31.beam0.spw12.ms"
+    expected_4 = "SB1234.RACS_0635-31.beam00.spw12.ms"
     ms_path_4 = create_ms_name(ms_path=example_path_4, sbid=1234, field="RACS_0635-31")
     assert isinstance(ms_path_4, str)
     assert ms_path_4 == expected_4
@@ -295,18 +295,18 @@ def test_create_ms_name():
 
 def test_create_ms_name_no_sbid():
     example_path = "2022-04-14_100122_0.ms"
-    expected = "SB0000.beam0.ms"
+    expected = "SB0000.beam00.ms"
     ms_path = create_ms_name(ms_path=example_path)
     assert isinstance(ms_path, str)
     assert ms_path == expected
 
-    expected_2 = "SB0000.RACS_0635-31.beam0.ms"
+    expected_2 = "SB0000.RACS_0635-31.beam00.ms"
     ms_path_2 = create_ms_name(ms_path=example_path, field="RACS_0635-31")
     assert isinstance(ms_path_2, str)
     assert ms_path_2 == expected_2
 
     example_path_3 = "2022-04-14_100122_0_12.ms"
-    expected_3 = "SB0000.RACS_0635-31.beam0.spw12.ms"
+    expected_3 = "SB0000.RACS_0635-31.beam00.spw12.ms"
     ms_path_3 = create_ms_name(ms_path=example_path_3, field="RACS_0635-31")
     assert isinstance(ms_path_3, str)
     assert ms_path_3 == expected_3


### PR DESCRIPTION
Started to annoy me enough to change the formatting field for `beam` to make it a zero padded two digit number. Tests were changed to reflect this and workflows seem to continue to run correctly. 