### PR TITLE
Create Copy/Temporary context managers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 - Added new masking modes
 - More Option types available in the template configuration
 - Tarball of files and linmos fields
-
+- Added context managers to help with MEMDIR / LOCALDIR like variables
+- 
 ## Pre 0.2.3
 
 Everything chsnges all the time

--- a/flint/utils.py
+++ b/flint/utils.py
@@ -36,8 +36,12 @@ def hold_then_move_into(
     if hold_directory == move_directory:
         yield move_directory
     else:
-        hold_directory.mkdir(parents=True, exist_ok=True)
-        move_directory.mkdir(parents=True, exist_ok=True)
+        for directory in (hold_directory, move_directory):
+            if directory.exists():
+                assert directory.is_dir()
+            else:
+                directory.mkdir(parents=True)
+
         assert all([d.is_dir() for d in (hold_directory, move_directory)])
 
         yield hold_directory

--- a/flint/utils.py
+++ b/flint/utils.py
@@ -5,6 +5,7 @@ for general usage.
 import os
 import shutil
 import subprocess
+from contextlib import contextmanager
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
 
@@ -22,6 +23,25 @@ from flint.logging import logger
 # struct should be considered. The the astropy.io.fits.Header might be
 # appropriate to pass around between dask / prefect delayed functions. Something
 # that only opens the FITS file once and places things into common field names.
+
+
+@contextmanager
+def temporarily_move_into(subject: Path, temporary_directory: Optional[Path] = None):
+
+    if temporary_directory is None:
+        yield subject
+    else:
+        temporary_directory.mkdir(parents=True, exist_ok=True)
+        assert (
+            temporary_directory.is_dir()
+        ), f"{temporary_directory=} exists and is not a folder"
+        output_item = temporary_directory / subject.name
+        assert not output_item.exists(), f"{output_item=} alreadt exists! "
+        logger.info(f"Moving {subject=} to {output_item=}")
+
+        # Move file into temporary_directory
+        # yield the updated item
+        # Move file from temporary copy back to the original
 
 
 def get_environment_variable(variable: str) -> Union[str, None]:

--- a/flint/utils.py
+++ b/flint/utils.py
@@ -29,7 +29,22 @@ from flint.logging import logger
 def hold_then_move_into(
     hold_directory: Path, move_directory: Path, delete_hold_on_exist: bool = True
 ) -> Path:
+    """Create a temporary directory such that anything within it one the
+    exit of the context manager is copied over to `move_directory`.
 
+    Args:
+        hold_directory (Path): Location of directory to temporarily base work from
+        move_directory (Path): Final directort location to move items into
+        delete_hold_on_exist (bool, optional): Whether `hold_directory` is deleted on exit of the context. Defaults to True.
+
+    Returns:
+        Path: Path to the temporary folder
+
+    Yields:
+        Iterator[Path]: Path to the temporary folder
+    """
+    # TODO: except extra files and folders to copy into `hold_directory` that are
+    # also placed back on exit
     hold_directory = Path(hold_directory)
     move_directory = Path(move_directory)
 

--- a/flint/utils.py
+++ b/flint/utils.py
@@ -26,6 +26,31 @@ from flint.logging import logger
 
 
 @contextmanager
+def hold_then_move_into(
+    hold_directory: Path, move_directory: Path, delete_hold_on_exist: bool = True
+) -> Path:
+
+    hold_directory = Path(hold_directory)
+    move_directory = Path(move_directory)
+
+    if hold_directory == move_directory:
+        yield move_directory
+    else:
+        hold_directory.mkdir(parents=True, exist_ok=True)
+        move_directory.mkdir(parents=True, exist_ok=True)
+        assert all([d.is_dir() for d in (hold_directory, move_directory)])
+
+        yield hold_directory
+
+        for file_or_folder in hold_directory.glob("*"):
+            logger.info(f"Moving {file_or_folder=} to {move_directory=}")
+            shutil.move(str(file_or_folder), move_directory)
+
+        if delete_hold_on_exist:
+            remove_files_folders(hold_directory)
+
+
+@contextmanager
 def temporarily_move_into(
     subject: Path, temporary_directory: Optional[Path] = None
 ) -> Path:

--- a/flint/utils.py
+++ b/flint/utils.py
@@ -26,7 +26,9 @@ from flint.logging import logger
 
 
 @contextmanager
-def temporarily_move_into(subject: Path, temporary_directory: Optional[Path] = None):
+def temporarily_move_into(
+    subject: Path, temporary_directory: Optional[Path] = None
+) -> Path:
     """Given a file or folder, temporarily copy it into the path specified
     by `temporary_directory` for the duration of the context manager. Upon
     exit the original copy, specified by `subject`, is removed and replaced
@@ -65,8 +67,9 @@ def temporarily_move_into(subject: Path, temporary_directory: Optional[Path] = N
         logger.info(f"Moving {subject=} to {output_item=}")
 
         if subject.is_dir():
+            logger.info(f"{subject=} is a directory, recursively copying")
             copy_directory(
-                input_directory=subject, output_directory=output_item.parent.absolute()
+                input_directory=subject, output_directory=output_item.absolute()
             )
         else:
             shutil.copy(subject, output_item)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -45,7 +45,7 @@ def test_hold_then_test_errors(tmpdir):
     b.touch()
 
     with pytest.raises(AssertionError):
-        with hold_then_move_into(hold_directory=a, move_directory=b) as not_needed:
+        with hold_then_move_into(hold_directory=a, move_directory=b) as _:
             logger.info("This will not be here")
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,6 +28,27 @@ from flint.utils import (
 )
 
 
+def test_hold_then_move_same_folder(tmpdir):
+    a = Path(tmpdir) / "Captin"
+
+    with hold_then_move_into(hold_directory=a, move_directory=a) as example:
+        assert a == example
+
+
+def test_hold_then_test_errors(tmpdir):
+    """Make sure some basic error handling"""
+
+    a = Path(tmpdir) / "Jack.txt"
+    b = Path(tmpdir) / "Sparrow.txt"
+
+    a.touch()
+    b.touch()
+
+    with pytest.raises(AssertionError):
+        with hold_then_move_into(hold_directory=a, move_directory=b) as not_needed:
+            logger.info("This will not be here")
+
+
 def test_hold_then_move_into(tmpdir):
     """See whether the hold directory can have things dumped into it, then
     moved into place on exit of the context manager"""


### PR DESCRIPTION
In an effort to nicely handle potential use of SLURM `$MEMDIR` and `$LOCALDIR` type local storage mechanisms I have attempted to spec out a couple context managers to help out. 

The idea being that on entry to the context the necessarily files are copied over to the compute node local storage space while creating folders along the way, work is performed (e.g. wsclean on the local copy), and output files are copied back. 

There are two managers:
- `temporarily_move_into`: a subject directory or file is temporarily copied over to a temporary folder, work is performed, and it is copied back. The subject is the only item intended to be moved back, other files created along the way may not be. 
- `hold_then_move_into`: a folder if created where anything inside of it at the end of the context manager is copied over to the final directory. 

Very much a toy at this point, but tests in `tests/test_utils.py` seem to mock up the expected behaviour with the use cases I have in mind. Likely can be evolved, e.g. add some extra files to place into `hold_then_move_into` on that folders creation. 