### PR TITLE
Rename MSs as they are going through self-calibration and imaging rounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - added in skip rounds for masking and selfcal
 - Basic handling of CASDA measurement sets (preprocessing)
 - Basic handling of environment variables in Options, only supported in WSCleanOptions (no need for others yet)
+- basic renaming of MS and shuffling column names in place of straight up copying the MS
 
 ## 0.2.4
 

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -488,34 +488,6 @@ def wsclean_imager(
     return wsclean_cmd
 
 
-def create_template_wsclean_options(
-    input_wsclean_options: WSCleanOptions,
-) -> WSCleanOptions:
-    """Construct a simple instance of WSClean options that will not
-    actually clean. This is intended to be used to get a representations
-    FITS header with appropriate WSC information.
-
-    Args:
-        input_wsclean_options (WSCleanOptions): The base set of wsclean options to use
-
-    Returns:
-        WSCleanOptions: Template options to use for the wsclean fits header creation
-    """
-
-    template_options = WSCleanCommand(
-        size=input_wsclean_options.size,
-        channels_out=1,
-        nmiter=0,
-        niter=1,
-        data_column=input_wsclean_options.data_column,
-        scale=input_wsclean_options.scale,
-        name=f"{input_wsclean_options.name}_template",
-    )
-    logger.info(f"Template options are {template_options}")
-
-    return template_options
-
-
 def get_parser() -> ArgumentParser:
     parser = ArgumentParser(description="Routines related to wsclean")
 

--- a/flint/ms.py
+++ b/flint/ms.py
@@ -4,10 +4,10 @@ from __future__ import (  # Used for mypy/pylance to like the return type of MS.
     annotations,
 )
 
-from curses.ascii import controlnames
 import shutil
 from argparse import ArgumentParser
 from contextlib import contextmanager
+from curses.ascii import controlnames
 from os import PathLike
 from pathlib import Path
 from typing import List, NamedTuple, Optional, Tuple, Union

--- a/flint/options.py
+++ b/flint/options.py
@@ -104,3 +104,5 @@ class FieldOptions(NamedTuple):
     """Path that SBID archive tarballs will be created under. If None no archive tarballs are created. See ArchiveOptions. """
     sbid_copy_path: Optional[Path] = None
     """Path that final processed products will be copied into. If None no copying of file products is performed. See ArchiveOptions. """
+    rename_ms: bool = False
+    """Rename MSs throught rounds of imaging and self-cal instead of creating copies. This will delete data-columns throughout. """

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -213,20 +213,22 @@ def task_zip_ms(in_item: WSCleanCommand) -> Path:
 
 @task
 def task_gaincal_applycal_ms(
-    wsclean_cmd: WSCleanCommand,
+    ms: Union[MS, WSCleanCommand],
     round: int,
     update_gain_cal_options: Optional[Dict[str, Any]] = None,
     archive_input_ms: bool = False,
     skip_selfcal: bool = False,
+    rename_ms: bool = False,
 ) -> MS:
     """Perform self-calibration using CASA gaincal and applycal.
 
     Args:
-        wsclean_cmd (WSCleanCommand): A resulting wsclean output. This is used purely to extract the ``.ms`` attribute.
+        ms (Union[MS, WSCleanCommand]): A resulting wsclean output. This is used purely to extract the ``.ms`` attribute.
         round (int): Counter indication which self-calibration round is being performed. A name is included based on this.
         update_gain_cal_options (Optional[Dict[str, Any]], optional): Options used to overwrite the default ``gaincal`` options. Defaults to None.
         archive_input_ms (bool, optional): If True the input measurement set is zipped. Defaults to False.
         skip_selfcal (bool, optional): Should this self-cal be skipped. If `True`, the a new MS is created but not calibrated the appropriate new name and returned.
+        rename_ms (bool, optional): It `True` simply rename a MS and adjust columns appropriately (potentially deleting them) instead of copying the complete MS. If `True` `archive_input_ms` is ignored. Defaults to False.
 
     Raises:
         ValueError: Raised when a ``.ms`` attribute can not be obtained
@@ -236,7 +238,7 @@ def task_gaincal_applycal_ms(
     """
     # TODO: Need to do a better type system to include the .ms
     # TODO: This needs to be expanded to handle multiple MS
-    ms = wsclean_cmd.ms
+    ms = ms if isinstance(ms, MS) else ms.ms  # type: ignore
 
     if not isinstance(ms, MS):
         raise ValueError(
@@ -249,6 +251,7 @@ def task_gaincal_applycal_ms(
         update_gain_cal_options=update_gain_cal_options,
         archive_input_ms=archive_input_ms,
         skip_selfcal=skip_selfcal,
+        rename_ms=rename_ms,
     )
 
 

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -349,6 +349,7 @@ def process_science_fields(
                 update_gain_cal_options=unmapped(gain_cal_options),
                 archive_input_ms=field_options.zip_ms,
                 skip_selfcal=skip_gaincal_current_round,
+                rename_ms=field_options.rename_ms,
                 wait_for=[
                     field_summary
                 ],  # To make sure field summary is created with unzipped MSs
@@ -672,6 +673,12 @@ def get_parser() -> ArgumentParser:
         action="store_true",
         help="Skip checking whether the path containing bandpass solutions exists (e.g. if solutions have already been applied)",
     )
+    parser.add_argument(
+        "--move-mss",
+        action="store_true",
+        default=False,
+        help="Rename MSs throught rounds of imaging and self-cal instead of creating copies. This will delete data-columns throughout. ",
+    )
 
     return parser
 
@@ -714,6 +721,7 @@ def cli() -> None:
         imaging_strategy=args.imaging_strategy,
         sbid_archive_path=args.sbid_archive_path,
         sbid_copy_path=args.sbid_copy_path,
+        rename_ms=args.rename_ms,
     )
 
     setup_run_process_science_field(

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -674,7 +674,7 @@ def get_parser() -> ArgumentParser:
         help="Skip checking whether the path containing bandpass solutions exists (e.g. if solutions have already been applied)",
     )
     parser.add_argument(
-        "--move-mss",
+        "--rename-ms",
         action="store_true",
         default=False,
         help="Rename MSs throught rounds of imaging and self-cal instead of creating copies. This will delete data-columns throughout. ",

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -344,7 +344,7 @@ def process_science_fields(
             )
 
             cal_mss = task_gaincal_applycal_ms.map(
-                wsclean_cmd=wsclean_cmds,
+                ms=wsclean_cmds,
                 round=current_round,
                 update_gain_cal_options=unmapped(gain_cal_options),
                 archive_input_ms=field_options.zip_ms,

--- a/flint/summary.py
+++ b/flint/summary.py
@@ -19,6 +19,9 @@ from astropy.coordinates import (
 from astropy.table import Table
 from astropy.time import Time
 
+# Addressing some time interval IERS issue with astropy.
+from astropy.utils.iers import conf
+
 from flint.coadd.linmos import LinmosCommand
 from flint.imager.wsclean import ImageSet, WSCleanCommand
 from flint.logging import logger
@@ -33,9 +36,6 @@ from flint.ms import (
 from flint.naming import get_sbid_from_path, processed_ms_format
 from flint.source_finding.aegean import AegeanOutputs
 from flint.utils import estimate_skycoord_centre
-
-# Addressing some time interval IERS issue with astropy.
-from astropy.utils.iers import conf
 
 conf.auto_max_age = None
 

--- a/flint/utils.py
+++ b/flint/utils.py
@@ -427,12 +427,15 @@ def zip_folder(
     Returns:
         Path: the path of the compressed zipped folder
     """
-
+    in_path = Path(in_path)
     out_zip = in_path if out_zip is None else out_zip
 
-    logger.info(f"Zipping {in_path}.")
-    shutil.make_archive(str(out_zip), format=archive_format, base_dir=str(in_path))
-    remove_files_folders(in_path)
+    if in_path.exists():
+        logger.info(f"Zipping {in_path}.")
+        shutil.make_archive(str(out_zip), format=archive_format, base_dir=str(in_path))
+        remove_files_folders(in_path)
+    else:
+        logger.warning(f"{input_path=} does not exist... Not archiving. ")
 
     return out_zip
 

--- a/flint/utils.py
+++ b/flint/utils.py
@@ -435,7 +435,7 @@ def zip_folder(
         shutil.make_archive(str(out_zip), format=archive_format, base_dir=str(in_path))
         remove_files_folders(in_path)
     else:
-        logger.warning(f"{input_path=} does not exist... Not archiving. ")
+        logger.warning(f"{in_path=} does not exist... Not archiving. ")
 
     return out_zip
 

--- a/tests/test_ms.py
+++ b/tests/test_ms.py
@@ -140,7 +140,6 @@ def test_check_column_in_ms(ms_example):
 
 
 def _get_columns(ms_path):
-
     with table(str(ms_path), readonly=True, ack=False) as tab:
         return tab.colnames()
 


### PR DESCRIPTION
Recently some EMU datasets were put through flint and it became clear that copying the entire MS in preparation for self-calibration was a little nasty to the disk. 

In this pull request I introduce a CLI option `--rename-ms` that will simply rename the MS and modify column names appropriately. Although we lose the data between rounds, there is still the `INSTRUMENT_DATA` column that can be rotated back into the sky-frame, and the calibration tables that can then be applied. 