### PR TITLE
CLI arg to convol to desired resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Basic handling of CASDA measurement sets (preprocessing)
 - Basic handling of environment variables in Options, only supported in WSCleanOptions (no need for others yet)
 - basic renaming of MS and shuffling column names in place of straight up copying the MS
+- added CLI argument `--fixed-beam-shape` to specify a fixed final resolution, overwritng the optimal beam shape that otherwise would be computed
 
 ## 0.2.4
 

--- a/flint/options.py
+++ b/flint/options.py
@@ -88,6 +88,8 @@ class FieldOptions(NamedTuple):
     """Linmos the cleaning residuals together into a field image"""
     beam_cutoff: float = 150
     """Cutoff in arcseconds to use when calculating the common beam to convol to"""
+    fixed_beam_shape: Optional[List[float]] = None
+    """Specify the final beamsize of linmos field images in (arcsec, arcsec, deg)"""
     pb_cutoff: float = 0.1
     """Primary beam attentuation cutoff to use during linmos"""
     use_preflagger: bool = True

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -309,6 +309,9 @@ def task_get_common_beam(
     Returns:
         BeamShape: The final convolving beam size to be used
     """
+    # TODO: This function could have a wrapper around it that checks to see if
+    # fixed_beam_shape is present, and simply return, avoiding using this funcitons
+    # .submit method. Ahhh.
     if fixed_beam_shape:
         beam_shape = BeamShape(
             bmaj_arcsec=fixed_beam_shape[0],

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -296,7 +296,7 @@ def task_get_common_beam(
     wsclean_cmds: Collection[WSCleanCommand],
     cutoff: float = 25,
     filter: Optional[str] = None,
-    fixed_beam_shape: Optional[List[float, float, float]] = None,
+    fixed_beam_shape: Optional[List[float]] = None,
 ) -> BeamShape:
     """Compute a common beam size that all input images will be convoled to.
 
@@ -304,7 +304,7 @@ def task_get_common_beam(
         wsclean_cmds (Collection[WSCleanCommand]): Input images whose restoring beam properties will be considered
         cutoff (float, optional): Major axis larger than this valur, in arcseconds, will be ignored. Defaults to 25.
         filter (Optional[str], optional): Only include images when considering beam shape if this string is in the file path. Defaults to None.
-        fixed_beam_shape (Optional[List[float,float,float]], optional): Specify the final beamsize of linmos field images in (arcsec, arcsec, deg). If None it is deduced from images. Defauls to None;
+        fixed_beam_shape (Optional[List[float]], optional): Specify the final beamsize of linmos field images in (arcsec, arcsec, deg). If None it is deduced from images. Defauls to None;
 
     Returns:
         BeamShape: The final convolving beam size to be used

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -10,7 +10,6 @@ from typing import Any, Collection, Dict, List, Optional, TypeVar, Union
 import pandas as pd
 from prefect import task, unmapped
 from prefect.artifacts import create_table_artifact
-from regex import B
 
 from flint.calibrate.aocalibrate import (
     ApplySolutions,

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -274,7 +274,10 @@ def process_science_fields(
         )
 
     beam_shape = task_get_common_beam.submit(
-        wsclean_cmds=wsclean_cmds, cutoff=field_options.beam_cutoff, filter="-MFS-"
+        wsclean_cmds=wsclean_cmds,
+        cutoff=field_options.beam_cutoff,
+        filter="-MFS-",
+        fixed_beam_shape=field_options.fixed_beam_shape,
     )
     conv_images = task_convolve_image.map(
         wsclean_cmd=wsclean_cmds,
@@ -401,6 +404,7 @@ def process_science_fields(
                 wsclean_cmds=wsclean_cmds,
                 cutoff=field_options.beam_cutoff,
                 filter="-MFS-",
+                fixed_beam_shape=field_options.fixed_beam_shape,
             )
             conv_images = task_convolve_image.map(
                 wsclean_cmd=wsclean_cmds,
@@ -624,6 +628,13 @@ def get_parser() -> ArgumentParser:
         help="Cutoff in arcseconds that is used to flagged synthesised beams were deriving a common resolution to smooth to when forming the linmos images",
     )
     parser.add_argument(
+        "--fixed-beam-shape",
+        nargs=3,
+        type=float,
+        default=None,
+        help="Specify the final beamsize of linmos field images in (arcsec, arcsec, deg)",
+    )
+    parser.add_argument(
         "--pb-cutoff",
         type=float,
         default=0.1,
@@ -710,6 +721,7 @@ def cli() -> None:
         reference_catalogue_directory=args.reference_catalogue_directory,
         linmos_residuals=args.linmos_residuals,
         beam_cutoff=args.beam_cutoff,
+        fixed_beam_shape=args.fixed_beam_shape,
         pb_cutoff=args.pb_cutoff,
         use_preflagger=args.use_preflagger,
         use_beam_masks=args.use_beam_masks,


### PR DESCRIPTION
Add a CLI argument around convolving to a fixed final resolution. This overwrites what would otherwise be the optimal beam derived from the data. 

If a beam can not be convolved to the final resolution it should be nan'd and subsequently ignored. Though some more thorough testing should be considered here. 