### PR TITLE
Make the bandpass_calibration_solutions cli optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Basic handling of environment variables in Options, only supported in WSCleanOptions (no need for others yet)
 - basic renaming of MS and shuffling column names in place of straight up copying the MS
 - added CLI argument `--fixed-beam-shape` to specify a fixed final resolution, overwritng the optimal beam shape that otherwise would be computed
+- Added a SlurmInfo class to help with debugging crashed jobs. Primative and likely to change. 
+- Made the `calibrated_bandpass_path` and optional CLI argument so that CASDA MSs can be better handled
 
 ## 0.2.4
 
@@ -13,7 +15,7 @@
 - More Option types available in the template configuration
 - Tarball of files and linmos fields
 - Added context managers to help with MEMDIR / LOCALDIR like variables
--
+
 ## Pre 0.2.3
 
 Everything chsnges all the time

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -135,9 +135,9 @@ def _load_and_copy_strategy(
 @flow(name="Flint Continuum Pipeline")
 def process_science_fields(
     science_path: Path,
-    bandpass_path: Path,
     split_path: Path,
     field_options: FieldOptions,
+    bandpass_path: Optional[Path] = None,
 ) -> None:
     # Verify no nasty incompatible options
     _check_field_options(field_options=field_options)
@@ -179,6 +179,8 @@ def process_science_fields(
         # TODO: This will likely need to be expanded should any
         # other calibration strategies get added
         # Scan the existing bandpass directory for the existing solutions
+        assert bandpass_path, f"{bandpass_path=}, it needs to be set"
+
         calibrate_cmds = find_existing_solutions(
             bandpass_directory=bandpass_path,
             use_preflagged=field_options.use_preflagger,
@@ -471,12 +473,12 @@ def process_science_fields(
 def setup_run_process_science_field(
     cluster_config: Union[str, Path],
     science_path: Path,
-    bandpass_path: Path,
     split_path: Path,
     field_options: FieldOptions,
+    bandpass_path: Optional[Path] = None,
     skip_bandpass_check: bool = False,
 ) -> None:
-    if not skip_bandpass_check:
+    if not skip_bandpass_check and bandpass_path:
         assert (
             bandpass_path.exists() and bandpass_path.is_dir()
         ), f"{bandpass_path=} needs to exist and be a directory! "
@@ -510,7 +512,7 @@ def get_parser() -> ArgumentParser:
         help="Path to directories containing the beam-wise science measurementsets that will have solutions copied over and applied.",
     )
     parser.add_argument(
-        "calibrated_bandpass_path",
+        "--calibrated_bandpass_path",
         type=Path,
         default=None,
         help="Path to directory containing the uncalibrated beam-wise measurement sets that contain the bandpass calibration source. If None then the '--sky-model-directory' should be provided. ",

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -512,7 +512,7 @@ def get_parser() -> ArgumentParser:
         help="Path to directories containing the beam-wise science measurementsets that will have solutions copied over and applied.",
     )
     parser.add_argument(
-        "--calibrated_bandpass_path",
+        "--calibrated-bandpass-path",
         type=Path,
         default=None,
         help="Path to directory containing the uncalibrated beam-wise measurement sets that contain the bandpass calibration source. If None then the '--sky-model-directory' should be provided. ",

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -33,7 +33,7 @@ def test_config_field_options(tmpdir):
     parser = get_parser()
     args = parser.parse_args(
         f"""/scratch3/gal16b/askap_sbids/112334/
-        /scratch3/gal16b/askap_sbids/111/
+        --calibrated-bandpass-path /scratch3/gal16b/askap_sbids/111/
         --cli-config {str(output_file)}""".split()
     )
 
@@ -68,7 +68,7 @@ def test_create_field_options():
     parser = get_parser()
     args = parser.parse_args(
         """/scratch3/gal16b/askap_sbids/112334/
-        /scratch3/gal16b/askap_sbids/111/
+        --calibrated-bandpass-path /scratch3/gal16b/askap_sbids/111/
         --holofile /scratch3/projects/spiceracs/RACS_Low2_Holography/akpb.iquv.square_6x6.63.887MHz.SB39549.cube.fits
         --calibrate-container /scratch3/gal16b/containers/calibrate.sif
         --flagger-container /scratch3/gal16b/containers/aoflagger.sif
@@ -116,7 +116,7 @@ def test_create_field_options2():
     parser = get_parser()
     args = parser.parse_args(
         """/scratch3/gal16b/askap_sbids/112334/
-        /scratch3/gal16b/askap_sbids/111/
+        --calibrated-bandpass-path /scratch3/gal16b/askap_sbids/111/
         --holofile /scratch3/projects/spiceracs/RACS_Low2_Holography/akpb.iquv.square_6x6.63.887MHz.SB39549.cube.fits
         --calibrate-container /scratch3/gal16b/containers/calibrate.sif
         --flagger-container /scratch3/gal16b/containers/aoflagger.sif

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -157,3 +157,51 @@ def test_create_field_options2():
     assert field_options.linmos_residuals is False
     assert field_options.rounds == 2
     assert isinstance(field_options.wsclean_container, Path)
+
+
+def test_create_field_options3():
+    """Make sure that the calibrated-bandpass-path can be left unchecked"""
+    parser = get_parser()
+    args = parser.parse_args(
+        """/scratch3/gal16b/askap_sbids/112334/
+        --holofile /scratch3/projects/spiceracs/RACS_Low2_Holography/akpb.iquv.square_6x6.63.887MHz.SB39549.cube.fits
+        --calibrate-container /scratch3/gal16b/containers/calibrate.sif
+        --flagger-container /scratch3/gal16b/containers/aoflagger.sif
+        --wsclean-container /scratch3/projects/spiceracs/singularity_images/wsclean_force_mask.sif
+        --yandasoft-container /scratch3/gal16b/containers/yandasoft.sif
+        --cluster-config /scratch3/gal16b/split/petrichor.yaml
+        --selfcal-rounds 2
+        --split-path $(pwd)
+        --run-aegean
+        --aegean-container '/scratch3/gal16b/containers/aegean.sif'
+        --reference-catalogue-directory '/scratch3/gal16b/reference_catalogues/'
+        --use-preflagger
+    """.split()
+    )
+
+    field_options = FieldOptions(
+        flagger_container=args.flagger_container,
+        calibrate_container=args.calibrate_container,
+        holofile=args.holofile,
+        expected_ms=args.expected_ms,
+        wsclean_container=args.wsclean_container,
+        yandasoft_container=args.yandasoft_container,
+        rounds=args.selfcal_rounds,
+        zip_ms=args.zip_ms,
+        run_aegean=args.run_aegean,
+        aegean_container=args.aegean_container,
+        no_imaging=args.no_imaging,
+        reference_catalogue_directory=args.reference_catalogue_directory,
+        linmos_residuals=args.linmos_residuals,
+        beam_cutoff=args.beam_cutoff,
+        pb_cutoff=args.pb_cutoff,
+        use_preflagger=args.use_preflagger,
+    )
+
+    assert isinstance(field_options, FieldOptions)
+    assert field_options.use_preflagger is True
+    assert field_options.zip_ms is False
+    assert field_options.linmos_residuals is False
+    assert field_options.rounds == 2
+    assert isinstance(field_options.wsclean_container, Path)
+    assert args.calibrated_bandpass_path is None


### PR DESCRIPTION
Now that MSs from casda can be imaged with the continuum pipeline it is not longer necessary to enforce a set of bandpass solutions to be specified. 

This makes it optional. Should raw askap ms data be processed then the `bandpass_calibrate_solutions` will be required for processing. 