### PR TITLE
Allow folders to be copied in archive copy 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - added CLI argument `--fixed-beam-shape` to specify a fixed final resolution, overwritng the optimal beam shape that otherwise would be computed
 - Added a SlurmInfo class to help with debugging crashed jobs. Primative and likely to change.
 - Made the `calibrated_bandpass_path` and optional CLI argument so that CASDA MSs can be better handled
+- copying folders in `copy_files_into` when archiving
 
 ## 0.2.4
 

--- a/flint/archive.py
+++ b/flint/archive.py
@@ -52,7 +52,8 @@ def resolve_glob_expressions(
 
 
 def copy_files_into(copy_out_path: Path, files_to_copy: Collection[Path]) -> Path:
-    """Copy a set of specified files into an output directory
+    """Copy a set of specified files into an output directory, If a file happens to
+    be a folder then it will be copied over.
 
     Args:
         copy_out_path (Path): Path to copy files into
@@ -70,15 +71,17 @@ def copy_files_into(copy_out_path: Path, files_to_copy: Collection[Path]) -> Pat
 
     logger.info(f"Copying {total} files into {copy_out_path}")
     for count, file in enumerate(files_to_copy):
-        logger.info(f"{count+1} of {total}, copying {file}")
 
-        if not file.is_file():
-            # TODO: Support folders
+        if file.is_file():
+            logger.info(f"{count+1} of {total}, copying file {file}")
+            shutil.copy(file, copy_out_path)
+        elif file.is_dir():
+            logger.info(f"{count+1} of {total}, copying folder {file}")
+            shutil.copytree(file, copy_out_path / file.name)
+        else:
             not_copied.append(file)
             logger.critical(f"{file} is not a file. Skipping. ")
             continue
-
-        shutil.copy(file, copy_out_path)
 
     if not_copied:
         logger.critical(f"Did not copy {len(not_copied)} files, {not_copied=}")

--- a/flint/archive.py
+++ b/flint/archive.py
@@ -71,7 +71,6 @@ def copy_files_into(copy_out_path: Path, files_to_copy: Collection[Path]) -> Pat
 
     logger.info(f"Copying {total} files into {copy_out_path}")
     for count, file in enumerate(files_to_copy):
-
         if file.is_file():
             logger.info(f"{count+1} of {total}, copying file {file}")
             shutil.copy(file, copy_out_path)

--- a/flint/archive.py
+++ b/flint/archive.py
@@ -76,6 +76,7 @@ def copy_files_into(copy_out_path: Path, files_to_copy: Collection[Path]) -> Pat
             logger.info(f"{count+1} of {total}, copying file {file}")
             shutil.copy(file, copy_out_path)
         elif file.is_dir():
+            # TODO: Add an option to tar folders into the final location
             logger.info(f"{count+1} of {total}, copying folder {file}")
             shutil.copytree(file, copy_out_path / file.name)
         else:


### PR DESCRIPTION
Previously when a set of regular expressions were being evaluated to select items to copy into an archive location it did not care about whether a subject was a file or folder. The actual copy function did though, and would skip folders. 

This change will copy folders over as well. 