### PR TITLE
Create multiple linmos images if --fixed-beam-shape is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - copying folders in `copy_files_into` when archiving
 - added reading of ArchiveOptions from strategy file for continuum pipeline and `flint_archive`
 - Adaptive colour bar scaling in the rms validation plot
+- Create multiple linmos images if `--fixed-beam-shape` specified, one at an optimal common resolution and another at the specified resolution
 
 ## 0.2.4
 

--- a/flint/naming.py
+++ b/flint/naming.py
@@ -5,9 +5,39 @@ products.
 import re
 from datetime import datetime
 from pathlib import Path
-from typing import Any, List, NamedTuple, Optional, Union
+from typing import Any, Dict, List, NamedTuple, Optional, Union
 
 from flint.logging import logger
+
+
+def get_beam_resolution_str(mode: str, marker: Optional[str] = None) -> str:
+    """Map a beam resolution mode to an appropriate suffix. This
+    is located her in anticipation of other imaging modes.
+
+    Supported modes are: 'optimal', 'fixed', 'raw'
+
+    Args:
+        mode (str): The mode of image resolution to use.
+        marker (Optional[str], optional): Append the marker to the end of the returned mode string. If None mode string is returned. Defaults to None.
+
+    Raises:
+        ValueError: Raised when an unrecognised mode is supplied
+
+    Returns:
+        str: The appropriate string for mapped mode
+    """
+    # NOTE: Arguably this is a trash and needless function. Adding it
+    # incase other modes are ever needed or referenced. No idea whether
+    # it will ever been needed and could be removed in future.
+    supported_modes: Dict[str, str] = dict(optimal="optimal", fixed="fixed", raw="raw")
+    if mode.lower() not in supported_modes.keys():
+        raise ValueError(
+            f"Received {mode=}, supported modes are {supported_modes.keys()}"
+        )
+
+    mode_str = supported_modes[mode.lower()]
+
+    return mode_str + marker if marker else mode_str
 
 
 def get_selfcal_ms_name(in_ms_path: Path, round: int = 1) -> Path:

--- a/flint/peel/potato.py
+++ b/flint/peel/potato.py
@@ -597,7 +597,7 @@ def _print_ms_colnames(ms: MS) -> MS:
     with table(str(ms.path)) as tab:
         colnames = tab.colnames()
 
-    logger.critical(f"The MS column names are: {colnames=}")
+    logger.debug(f"The MS column names are: {colnames=}")
 
     return ms
 

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -609,6 +609,7 @@ def _create_convol_linmos_images(
                 field_summary=field_summary,
                 convol_mode="residual",
                 convol_filter="-MFS-",
+                convol_suffix_str=convol_suffix_str,
             )
 
     return parsets

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -417,7 +417,7 @@ def task_convolve_image(
         image_paths=image_paths,
         beam_shape=beam_shape,
         cutoff=cutoff,
-        convol_suffix=convol_suffix,
+        convol_suffix=convol_suffix_str,
     )
 
 
@@ -505,7 +505,7 @@ def _convolve_linmos(
     linmos_suffix_str: str,
     cutoff: float = 0.05,
     field_summary: Optional[FieldSummary] = None,
-    convol_mode: Optional[str] = None,
+    convol_mode: str = "image",
     convol_filter: str = "-MFS-",
     convol_suffix_str: str = "conv",
 ) -> LinmosCommand:
@@ -519,7 +519,7 @@ def _convolve_linmos(
         linmos_suffix_str (str): The suffix string passed to the linmos parset name
         cutoff (float, optional): The primary beam attenuation cutoff supplied to linmos when coadding. Defaults to 0.05.
         field_summary (Optional[FieldSummary], optional): The summary of the field, including (importantly) to orientation of the third-axis. Defaults to None.
-        convol_mode (Optional[str], optional): The mode passed to the convol task to describe the images to extract. Support image or residual. If None assume image. Defaults to None.
+        convol_mode (str, optional): The mode passed to the convol task to describe the images to extract. Support image or residual.  Defaults to image.
         convol_filter (str, optional): A text file applied when assessing images to co-add. Defaults to '-MFS-'.
         convol_suffix_str (str, optional): The suffix added to the convolved images. Defaults to 'conv'.
 
@@ -599,7 +599,7 @@ def _create_convol_linmos_images(
             linmos_suffix_str=linmos_suffix_str,
             cutoff=field_options.pb_cutoff,
             field_summary=field_summary,
-            convol_mode=None,
+            convol_mode="image",
             convol_filter="-MFS-",
             convol_suffix_str=convol_suffix_str,
         )
@@ -613,7 +613,7 @@ def _create_convol_linmos_images(
                 linmos_suffix_str=f"{linmos_suffix_str}.residual",
                 cutoff=field_options.pb_cutoff,
                 field_summary=field_summary,
-                convol_mode="residuals",
+                convol_mode="residual",
                 convol_filter="-MFS-",
             )
 

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -526,12 +526,6 @@ def _convolve_linmos(
     Returns:
         LinmosCommand: Resulting linmos command parset
     """
-    beam_shape = task_get_common_beam.submit(
-        wsclean_cmds=wsclean_cmds,
-        cutoff=field_options.beam_cutoff,
-        filter="-MFS-",
-        fixed_beam_shape=field_options.fixed_beam_shape,
-    )
 
     conv_images = task_convolve_image.map(
         wsclean_cmd=wsclean_cmds,

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -558,7 +558,7 @@ def _create_convol_linmos_images(
     field_options: FieldOptions,
     field_summary: Optional[FieldSummary] = None,
     current_round: Optional[int] = None,
-) -> LinmosCommand:
+) -> List[LinmosCommand]:
     """Derive the approriate set of beam shapes and then produce corresponding
     convolved and co-added images
 
@@ -569,9 +569,9 @@ def _create_convol_linmos_images(
         current_round (Optional[int], optional): Which self-cal imaging round. If None 'noselfcal'. Defaults to None.
 
     Returns:
-        LinmosCommand: The linmos command of either the optimal resolution linmos image, or the fixed beam shape image if `field_options.fixed_beam_shape` has been set.
+        List[LinmosCommand]: The collection of linmos commands executed.
     """
-    parset: Optional[LinmosCommand] = None
+    parsets: List[LinmosCommand] = []
     main_linmos_suffix_str = f"round{current_round}" if current_round else "noselfcal"
 
     todo: List[Any, str] = [(None, "")]
@@ -603,6 +603,7 @@ def _create_convol_linmos_images(
             convol_filter="-MFS-",
             convol_suffix_str=convol_suffix_str,
         )
+        parsets.append(parset)
 
         if field_options.linmos_residuals:
             _convolve_linmos(
@@ -616,8 +617,7 @@ def _create_convol_linmos_images(
                 convol_filter="-MFS-",
             )
 
-    assert parset, f"{parset=}, but should not be!"
-    return parset
+    return parsets
 
 
 @task

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -39,7 +39,7 @@ from flint.ms import (
     rename_column_in_ms,
     split_by_field,
 )
-from flint.naming import FITSMaskNames, processed_ms_format, get_beam_resolution_str
+from flint.naming import FITSMaskNames, get_beam_resolution_str, processed_ms_format
 from flint.options import FieldOptions
 from flint.peel.potato import potato_peel
 from flint.prefect.common.utils import upload_image_as_artifact
@@ -578,7 +578,6 @@ def _create_convol_linmos_images(
         )
 
     for round_beam_shape, beam_str in todo:
-
         linmos_suffix_str = f"{beam_str}.{main_linmos_suffix_str}"
         convol_suffix_str = f"{beam_str}.conv"
 

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -352,6 +352,7 @@ def task_convolve_image(
     cutoff: float = 60,
     mode: str = "image",
     filter: Optional[str] = None,
+    convol_suffix_str: str = "conv",
 ) -> Collection[Path]:
     """Convolve images to a specified resolution
 
@@ -360,6 +361,7 @@ def task_convolve_image(
         beam_shape (BeamShape): The shape images will be convolved to
         cutoff (float, optional): Maximum major beam axis an image is allowed to have before it will not be convolved. Defaults to 60.
         filter (Optional[str], optional): This string must be contained in the image path for it to be convolved. Defaults to None.
+        convol_suffix_str (str, optional): The suffix added to the convolved images. Defaults to 'conv'.
 
     Returns:
         Collection[Path]: Path to the output images that have been convolved.
@@ -412,7 +414,10 @@ def task_convolve_image(
         )
 
     return convolve_images(
-        image_paths=image_paths, beam_shape=beam_shape, cutoff=cutoff
+        image_paths=image_paths,
+        beam_shape=beam_shape,
+        cutoff=cutoff,
+        convol_suffix=convol_suffix,
     )
 
 
@@ -500,32 +505,9 @@ def _convolve_linmos(
     linmos_suffix_str: str,
     cutoff: float = 0.05,
     field_summary: Optional[FieldSummary] = None,
-) -> LinmosCommand:
-    """An internal function that launches the convolution to a common resolution
-    and subsequent linmos of the wsclean images.
-
-    Args:
-        wsclean_cmds (Collection[WSCleanCommand]): Collection of wsclean imaging results, with residual images described in the attached ``ImageSet``
-        beam_shape (BeamShape): The beam shape that residual images will be convolved to
-        field_options (FieldOptions): Options related to the processing of the field
-        linmos_suffix_str (str): The suffix string passed to the linmos parset name
-        cutoff (float, optional): The primary beam attenuation cutoff supplied to linmos when coadding. Defaults to 0.05.
-        field_summary (Optional[FieldSummary], optional): The summary of the field, including (importantly) to orientation of the third-axis. Defaults to None.
-
-    Returns:
-        LinmosCommand: Resulting linmos command parset
-    """
-
-
-def _convolve_linmos(
-    wsclean_cmds: Collection[WSCleanCommand],
-    beam_shape: BeamShape,
-    field_options: FieldOptions,
-    linmos_suffix_str: str,
-    cutoff: float = 0.05,
-    field_summary: Optional[FieldSummary] = None,
     convol_mode: Optional[str] = None,
     convol_filter: str = "-MFS-",
+    convol_suffix_str: str = "conv",
 ) -> LinmosCommand:
     """An internal function that launches the convolution to a common resolution
     and subsequent linmos of the wsclean residual images.
@@ -539,19 +521,28 @@ def _convolve_linmos(
         field_summary (Optional[FieldSummary], optional): The summary of the field, including (importantly) to orientation of the third-axis. Defaults to None.
         convol_mode (Optional[str], optional): The mode passed to the convol task to describe the images to extract. Support image or residual. If None assume image. Defaults to None.
         convol_filter (str, optional): A text file applied when assessing images to co-add. Defaults to '-MFS-'.
+        convol_suffix_str (str, optional): The suffix added to the convolved images. Defaults to 'conv'.
 
     Returns:
         LinmosCommand: Resulting linmos command parset
     """
-    residual_conv_images = task_convolve_image.map(
+    beam_shape = task_get_common_beam.submit(
+        wsclean_cmds=wsclean_cmds,
+        cutoff=field_options.beam_cutoff,
+        filter="-MFS-",
+        fixed_beam_shape=field_options.fixed_beam_shape,
+    )
+
+    conv_images = task_convolve_image.map(
         wsclean_cmd=wsclean_cmds,
         beam_shape=unmapped(beam_shape),
         cutoff=150.0,
         mode=convol_mode,
         filter=convol_filter,
+        convol_suffix_str=convol_suffix_str,
     )
     parset = task_linmos_images.submit(
-        images=residual_conv_images,
+        images=conv_images,
         container=field_options.yandasoft_container,
         suffix_str=linmos_suffix_str,
         holofile=field_options.holofile,
@@ -559,6 +550,73 @@ def _convolve_linmos(
         field_summary=field_summary,
     )
 
+    return parset
+
+
+def _create_convol_linmos_images(
+    wsclean_cmds: Collection[WSCleanCommand],
+    field_options: FieldOptions,
+    field_summary: Optional[FieldSummary] = None,
+    current_round: Optional[int] = None,
+) -> LinmosCommand:
+    """Derive the approriate set of beam shapes and then produce corresponding
+    convolved and co-added images
+
+    Args:
+        wsclean_cmds (Collection[WSCleanCommand]): Set of wsclean commands that have been executed
+        field_options (FieldOptions): Set of field imaging optins, containing details of the beam/s
+        field_summary (Optional[FieldSummary], optional): Summary of the MSs, importantly containing their third-axis rotation. Defaults to None.
+        current_round (Optional[int], optional): Which self-cal imaging round. If None 'noselfcal'. Defaults to None.
+
+    Returns:
+        LinmosCommand: The linmos command of either the optimal resolution linmos image, or the fixed beam shape image if `field_options.fixed_beam_shape` has been set.
+    """
+    parset: Optional[LinmosCommand] = None
+    main_linmos_suffix_str = f"round{current_round}" if current_round else "noselfcal"
+
+    todo: List[Any, str] = [(None, "")]
+    if field_options.fixed_beam_shape:
+        logger.info(
+            f"Creating second round of linmos images with {field_options.fixed_beam_shape}"
+        )
+        todo.append((field_options.fixed_beam_shape, "fixed."))
+
+    for round_beam_shape, beam_str in todo:
+
+        linmos_suffix_str = f"{beam_str}{main_linmos_suffix_str}"
+        convol_suffix_str = f"{beam_str}conv"
+
+        beam_shape = task_get_common_beam.submit(
+            wsclean_cmds=wsclean_cmds,
+            cutoff=field_options.beam_cutoff,
+            filter="-MFS-",
+            fixed_beam_shape=round_beam_shape,
+        )
+        parset = _convolve_linmos(
+            wsclean_cmds=wsclean_cmds,
+            beam_shape=beam_shape,
+            field_options=field_options,
+            linmos_suffix_str=linmos_suffix_str,
+            cutoff=field_options.pb_cutoff,
+            field_summary=field_summary,
+            convol_mode=None,
+            convol_filter="-MFS-",
+            convol_suffix_str=convol_suffix_str,
+        )
+
+        if field_options.linmos_residuals:
+            _convolve_linmos(
+                wsclean_cmds=wsclean_cmds,
+                beam_shape=beam_shape,
+                field_options=field_options,
+                linmos_suffix_str=f"{linmos_suffix_str}.residual",
+                cutoff=field_options.pb_cutoff,
+                field_summary=field_summary,
+                convol_mode="residuals",
+                convol_filter="-MFS-",
+            )
+
+    assert parset, f"{parset=}, but should not be!"
     return parset
 
 

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -39,7 +39,7 @@ from flint.ms import (
     rename_column_in_ms,
     split_by_field,
 )
-from flint.naming import FITSMaskNames, processed_ms_format
+from flint.naming import FITSMaskNames, processed_ms_format, get_beam_resolution_str
 from flint.options import FieldOptions
 from flint.peel.potato import potato_peel
 from flint.prefect.common.utils import upload_image_as_artifact
@@ -568,17 +568,19 @@ def _create_convol_linmos_images(
     parsets: List[LinmosCommand] = []
     main_linmos_suffix_str = f"round{current_round}" if current_round else "noselfcal"
 
-    todo: List[Any, str] = [(None, "")]
+    todo: List[Any, str] = [(None, get_beam_resolution_str(mode="optimal"))]
     if field_options.fixed_beam_shape:
         logger.info(
             f"Creating second round of linmos images with {field_options.fixed_beam_shape}"
         )
-        todo.append((field_options.fixed_beam_shape, "fixed."))
+        todo.append(
+            (field_options.fixed_beam_shape, get_beam_resolution_str(mode="fixed"))
+        )
 
     for round_beam_shape, beam_str in todo:
 
-        linmos_suffix_str = f"{beam_str}{main_linmos_suffix_str}"
-        convol_suffix_str = f"{beam_str}conv"
+        linmos_suffix_str = f"{beam_str}.{main_linmos_suffix_str}"
+        convol_suffix_str = f"{beam_str}.conv"
 
         beam_shape = task_get_common_beam.submit(
             wsclean_cmds=wsclean_cmds,

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -304,7 +304,7 @@ def process_science_fields(
 
             if run_validation and field_options.reference_catalogue_directory:
                 _validation_items(
-                    field_summary=linmos_field_summary,
+                    field_summary=field_summary,
                     aegean_outputs=aegean_field_output,
                     reference_catalogue_directory=field_options.reference_catalogue_directory,
                 )

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -29,7 +29,6 @@ from flint.naming import (
 from flint.options import FieldOptions
 from flint.prefect.clusters import get_dask_runner
 from flint.prefect.common.imaging import (
-    _convolve_linmos,
     _create_convol_linmos_images,
     _validation_items,
     task_copy_and_preprocess_casda_askap_ms,
@@ -273,13 +272,6 @@ def process_science_fields(
         field_summary = task_update_with_options.submit(
             input_object=field_summary, beam_summaries=beam_summaries
         )
-
-    beam_shape = task_get_common_beam.submit(
-        wsclean_cmds=wsclean_cmds,
-        cutoff=field_options.beam_cutoff,
-        filter="-MFS-",
-        fixed_beam_shape=field_options.fixed_beam_shape,
-    )
 
     if field_options.yandasoft_container:
         parsets = _create_convol_linmos_images(

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -36,7 +36,6 @@ from flint.prefect.common.imaging import (
     task_create_image_mask_model,
     task_flag_ms_aoflagger,
     task_gaincal_applycal_ms,
-    task_get_common_beam,
     task_potato_peel,
     task_preprocess_askap_ms,
     task_rename_column_in_ms,

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -30,8 +30,8 @@ from flint.options import FieldOptions
 from flint.prefect.clusters import get_dask_runner
 from flint.prefect.common.imaging import (
     _convolve_linmos,
-    _validation_items,
     _create_convol_linmos_images,
+    _validation_items,
     task_copy_and_preprocess_casda_askap_ms,
     task_create_apply_solutions_cmd,
     task_create_image_mask_model,

--- a/flint/validation.py
+++ b/flint/validation.py
@@ -499,10 +499,10 @@ def plot_rms_map(
 
     # Pirate no believes get below 10uJy/beam mateeey. Percentile a little more
     # robust to outliers but much of a much
-    floor: float = max(1, np.log10(np.nanpercentile(rms_data * 1e6, 16)))  # type: ignore
+    floor: float = max(1, np.floort(np.log10(np.nanpercentile(rms_data, 16))))  # type: ignore
 
     im = ax.imshow(
-        np.log10(rms_data * 1e6),
+        np.log10(rms_data),
         vmin=floor,
         vmax=floor + 1.0,
         origin="lower",
@@ -530,7 +530,6 @@ def plot_rms_map(
 
     cbar = fig.colorbar(
         im,
-        cax=None,
         ax=ax,
         use_gridspec=True,
         pad=0.09,

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,5 +1,6 @@
 """Some tests related to components around measurement sets."""
 
+import pytest
 from datetime import datetime
 from pathlib import Path
 
@@ -15,12 +16,27 @@ from flint.naming import (
     extract_beam_from_name,
     extract_components_from_name,
     get_aocalibrate_output_path,
+    get_beam_resolution_str,
     get_potato_output_base_path,
     get_sbid_from_path,
     get_selfcal_ms_name,
     processed_ms_format,
     raw_ms_format,
 )
+
+
+def test_get_beam_resolution_str():
+    """Map the known / support modes of beam resolution in file names"""
+    assert "raw" == get_beam_resolution_str(mode="raw")
+    assert "optimal" == get_beam_resolution_str(mode="optimal")
+    assert "fixed" == get_beam_resolution_str(mode="fixed")
+
+    assert "raw!" == get_beam_resolution_str(mode="raw", marker="!")
+    assert "optimal?" == get_beam_resolution_str(mode="optimal", marker="?")
+    assert "fixed." == get_beam_resolution_str(mode="fixed", marker=".")
+
+    with pytest.raises(ValueError):
+        _ = get_beam_resolution_str("Jack")
 
 
 def test_casda_ms_format_1934():

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,8 +1,9 @@
 """Some tests related to components around measurement sets."""
 
-import pytest
 from datetime import datetime
 from pathlib import Path
+
+import pytest
 
 from flint.naming import (
     CASDANameComponents,


### PR DESCRIPTION
Previously flint would use `radio_beam` to compute the smallest beam that each image could be convolved to. It was requested to convol to a specified beam, which would be larger than this common beam. 

When this is activated two sets of images will be created - one convolved to an optimal resolution and one to the fixed beam shape. These are then appropriately linmos'd together. 