### PR TITLE
Trim the weights image from linmos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Adaptive colour bar scaling in the rms validation plot
 - Create multiple linmos images if `--fixed-beam-shape` specified, one at an optimal common resolution and another at the specified resolution
 - Dump the `FieldOptions` to the output science directory
+- Weights produced by `linmos` are also trimmed in the same way as the corresponding image
 
 ## 0.2.4
 

--- a/flint/coadd/linmos.py
+++ b/flint/coadd/linmos.py
@@ -414,7 +414,7 @@ def linmos_images(
 
     # Trim the fits image to remove empty pixels
     image_trim_results = trim_fits_image(image_path=linmos_names.image_fits)
-    weight_time_results = trim_fits_image(
+    trim_fits_image(
         image_path=linmos_names.weight_fits,
         bounding_box=image_trim_results.bounding_box,
     )
@@ -462,6 +462,13 @@ def get_parser() -> ArgumentParser:
         help="Path to the container with yandasoft tools",
     )
 
+    trim_parser = subparsers.add_parser(
+        "trim", help="Generate a yandasoft linmos parset"
+    )
+
+    trim_parser.add_argument(
+        "images", type=Path, nargs="+", help="The images that will be trimmed"
+    )
     return parser
 
 
@@ -489,6 +496,13 @@ def cli() -> None:
                 holofile=args.holofile,
                 container=args.yandasoft_container,
             )
+    elif args.mode == "trim":
+        images = args.images
+        logger.info(f"Will be trimming {len(images)}")
+        for image in images:
+            trim_fits_image(image_path=Path(image))
+    else:
+        logger.error(f"Unrecognised mode: {args.mode}")
 
 
 if __name__ == "__main__":

--- a/flint/coadd/linmos.py
+++ b/flint/coadd/linmos.py
@@ -277,8 +277,8 @@ def generate_linmos_parameter_set(
     logger.info(f"{len(img_str)} unique images from {len(images)} input collection. ")
     img_list: str = "[" + ",".join(img_str) + "]"
 
-    assert len(set(img_str)) == len(
-        images
+    assert (
+        len(set(img_str)) == len(images)
     ), "Some images were dropped from the linmos image string. Something is bad, walk the plank. "
 
     # If no weights_list has been provided (and therefore no optimal

--- a/tests/test_linmos_coadd.py
+++ b/tests/test_linmos_coadd.py
@@ -3,10 +3,10 @@ At the moment this is not testing the actual application. Just
 some of trhe helper functions around it.
 """
 
-import pytest
 from pathlib import Path
 
 import numpy as np
+import pytest
 from astropy.io import fits
 
 from flint.coadd.linmos import BoundingBox, create_bound_box, trim_fits_image


### PR DESCRIPTION
This will trim the weights image produced by linmos int he same way as the actual image is. 

Addresses #143 