### PR TITLE
Add coverage

### DIFF
--- a/.github/workflows/python-lint-test.yml
+++ b/.github/workflows/python-lint-test.yml
@@ -26,10 +26,14 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest pre-commit black mypy .
+        pip install pytest pytest-cov pre-commit black mypy .
     - name: Lint with pre-commit
       run: |
         pre-commit run --all-files
     - name: Test with pytest
       run: |
         pytest
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v4.0.1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,13 +27,11 @@ matplotlib = "*"
 prefect = "^2.10.0"
 prefect-dask = "^0.2.4"
 dask-jobqueue = "*"
-sphinx = "*"
 casadata = "^2023.7.3"
 #casatools = "6.5.3.28"
 casatasks = "6.5.1.23"
 RACS-tools = "^2.2.4"
 aegeantools = "2.3.0"
-pytest = "^7.4.0"
 radio-beam = "^0.3.4"
 reproject = "*"
 scikit-image = "*"
@@ -46,6 +44,22 @@ mypy = "^1.4.1"
 isort = "^5.12.0"
 pre-commit = "*"
 ruff = "^0.1.12"
+pytest = "^7.4.0"
+pytest-cov = "*"
+sphinx = "*"
+
+[tool.poetry.extras]
+dev = [
+    "black",
+    "mypy",
+    "isort",
+    "pre-commit",
+    "ruff",
+    "pytest",
+    "pytest-cov",
+    "sphinx",
+]
+
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Yarr let's plunder the booty of all the tests with coverage reports.

Required steps for this to work:

- Login to [codecov](https://app.codecov.io/) with GitHub
- Enable the flint `repo`
- Set `CODECOV_TOKEN` as 'Repository Secret' in settings > secrets and variable > actions

Optional extra post configuration:
- Add `codecov` badge to README