### PR TITLE
Archive the calibration tables once applied

### DIFF
--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -219,6 +219,7 @@ def task_gaincal_applycal_ms(
     archive_input_ms: bool = False,
     skip_selfcal: bool = False,
     rename_ms: bool = False,
+    archive_cal_table: bool = False,
 ) -> MS:
     """Perform self-calibration using CASA gaincal and applycal.
 
@@ -229,6 +230,7 @@ def task_gaincal_applycal_ms(
         archive_input_ms (bool, optional): If True the input measurement set is zipped. Defaults to False.
         skip_selfcal (bool, optional): Should this self-cal be skipped. If `True`, the a new MS is created but not calibrated the appropriate new name and returned.
         rename_ms (bool, optional): It `True` simply rename a MS and adjust columns appropriately (potentially deleting them) instead of copying the complete MS. If `True` `archive_input_ms` is ignored. Defaults to False.
+        archive_cal_table (bool, optional): Archive the output calibration table in a tarball. Defaults to False.
 
     Raises:
         ValueError: Raised when a ``.ms`` attribute can not be obtained
@@ -252,6 +254,7 @@ def task_gaincal_applycal_ms(
         archive_input_ms=archive_input_ms,
         skip_selfcal=skip_selfcal,
         rename_ms=rename_ms,
+        archive_cal_table=archive_cal_table,
     )
 
 

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -338,6 +338,7 @@ def process_science_fields(
                 archive_input_ms=field_options.zip_ms,
                 skip_selfcal=skip_gaincal_current_round,
                 rename_ms=field_options.rename_ms,
+                archive_cal_table=True,
                 wait_for=[
                     field_summary
                 ],  # To make sure field summary is created with unzipped MSs

--- a/flint/selfcal/casa.py
+++ b/flint/selfcal/casa.py
@@ -227,6 +227,7 @@ def gaincal_applycal_ms(
     raise_error_on_fail: bool = True,
     skip_selfcal: bool = False,
     rename_ms: bool = False,
+    archive_cal_table: bool = False,
 ) -> MS:
     """Perform self-calibration using casa's gaincal and applycal tasks against
     an input measurement set.
@@ -240,6 +241,7 @@ def gaincal_applycal_ms(
         raise_error_on_fail (bool, optional): If gaincal does not converge raise en error. if False and gain cal fails return the input ms. Defaults to True.
         skip_selfcal (bool, optional): Should this self-cal be skipped. If `True`, the a new MS is created but not calibrated the appropriate new name and returned.
         rename_ms (bool, optional): It `True` simply rename a MS and adjust columns appropriately (potentially deleting them) instead of copying the complete MS. If `True` `archive_input_ms` is ignored. Defaults to False.
+        archive_cal_table (bool, optional): Archive the output calibration table in a tarball. Defaults to False.
 
     Raises:
         GainCallError: Raised when raise_error_on_fail is True and gaincal does not converge.
@@ -322,6 +324,9 @@ def gaincal_applycal_ms(
         # At the time of writing merge_spws_in_ms returns the ms_path=,
         # but this pirate trusts no one.
         cal_ms = cal_ms.with_options(path=cal_ms_path)
+
+    if archive_cal_table:
+        zip_folder(in_path=cal_table)
 
     return cal_ms.with_options(column="CORRECTED_DATA")
 


### PR DESCRIPTION
The applied casa gaincal solutions can add up in terms of files on disk. This will tarball them by default. This is going to be safe since at the moment we do nothing with them anyway.