### PR TITLE
Detect and retry wsclean divergence error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     - the strategy format now has a `operations` set of keywords, including `stokesv` to drawn options from
     - naming format of output linmos files could contain the pol field
     - `stokesv` imaging will not linmos the cleaning residuals together, even if the `--linmos-residuals` CLI is provided
+- Capture `CleanDivergenceError` from `wsclean` and rerun with larger image size and lower gain
 
 # 0.2.5
 - added in skip rounds for masking and selfcal

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -303,8 +303,12 @@ def task_wsclean_imager(
             if "size" in update_wsclean_options
             else 8196
         )
-        mgain, gain = 0.7, 0.7
-        convergence_wsclean_options = dict(size=size, mgain=mgain, gain=gain)
+        mgain = (
+            max(0, update_wsclean_options["mgain"] - 0.1)
+            if "mgain" in update_wsclean_options
+            else 0.6
+        )
+        convergence_wsclean_options = dict(size=size, mgain=mgain)
         # dicts are mutable. Don't want to change for everything. Unclear to me
         # how prefect would behave here.
         update_wsclean_options = update_wsclean_options.copy().update(


### PR DESCRIPTION
In some fairly rare instances wsclean diverges during cleaning. However, a call back function is supplied and evaluated against the output logs from a wsclean command, and if a line of output has something to the effect of `Peak found at X kJy` a `CleanDivergenceError` is raised. 

This is a pretty simple attempt to capture that exception, and rerun wsclean with a larger image size and lower major gain. It is not bullet proof by any stretch, but it could help the occasional error where we have a bright source outside the field-of-view for a particular beam. 