### PR TITLE
Fixed outweight typo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
     rev: "v2.3.0"
     hooks:
       - id: codespell
-        args: ["-I", "ignore_words.txt"]
+        args: ["-I", "./ignore_words.txt"]
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: "v0.10.0.1"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,7 @@ repos:
     rev: "v2.3.0"
     hooks:
       - id: codespell
+        args: ["-L", "outweight"]
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: "v0.10.0.1"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
     rev: "v2.3.0"
     hooks:
       - id: codespell
-        args: ["-L", "outweight"]
+        args: ["-I", "ignore_words.txt"]
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: "v0.10.0.1"

--- a/flint/coadd/linmos.py
+++ b/flint/coadd/linmos.py
@@ -317,7 +317,7 @@ def generate_linmos_parameter_set(
         # f"linmos.beamangle        = {beam_angle_list}\n"
         f"linmos.imagetype        = fits\n"
         f"linmos.outname          = {str(parent_dir / linmos_names.image_fits.stem)}\n"
-        f"linmos.outweigh        = {str(parent_dir / linmos_names.weight_fits.stem)}\n"
+        f"linmos.outweight        = {str(parent_dir / linmos_names.weight_fits.stem)}\n"
         f"# For ASKAPsoft>1.3.0\n"
         f"linmos.useweightslog    = true\n"
         f"linmos.weighttype       = Combined\n"

--- a/flint/sclient.py
+++ b/flint/sclient.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from subprocess import CalledProcessError
 from time import sleep
-from typing import Callable, Collection, Optional, Union
+from typing import Callable, Collection, Optional, Union, List
 
 from spython.main import Client as sclient
 
@@ -37,7 +37,7 @@ def run_singularity_command(
     logger.info(f"Running {command} in {image}")
 
     job_info = log_job_environment()
-    bind: Union[None, list[str]] = None
+    bind: Union[None, List[str]] = None
     if bind_dirs:
         logger.info("Preparing bind directories")
         if isinstance(bind_dirs, Path):

--- a/flint/sclient.py
+++ b/flint/sclient.py
@@ -37,8 +37,9 @@ def run_singularity_command(
     logger.info(f"Running {command} in {image}")
 
     job_info = log_job_environment()
-
+    bind: Union[None,list[str]] = None
     if bind_dirs:
+        logger.info(f"Preparing bind directories")
         if isinstance(bind_dirs, Path):
             bind_dirs = [bind_dirs]
 

--- a/ignore_words.txt
+++ b/ignore_words.txt
@@ -1,1 +1,1 @@
-outweighht
+outweight

--- a/ignore_words.txt
+++ b/ignore_words.txt
@@ -1,0 +1,1 @@
+outweighht

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ import math
 import os
 import shutil
 from pathlib import Path
+from typing import Any
 
 import astropy.units as u
 import numpy as np
@@ -77,7 +78,7 @@ def test_hold_then_test_errors(tmpdir):
             logger.info("This will not be here")
 
 
-def test_hold_then_move_into_none(tmpdir):
+def test_hold_then_move_into_none(tmpdir: Any):
     """See whether the context manager behaves as expected when the temporary hold
     directory is None. This should just do thing in the move_directory."""
 
@@ -103,7 +104,7 @@ def test_hold_then_move_into_none(tmpdir):
     assert put_dir.exists()
 
 
-def test_hold_then_move_into(tmpdir):
+def test_hold_then_move_into(tmpdir: Any):
     """See whether the hold directory can have things dumped into it, then
     moved into place on exit of the context manager"""
 


### PR DESCRIPTION
Codespell incorrectly renamed the linmos parameter `outweight` to `outweigh`, which broke the co-adding stage. This fixes that, and adds the work to its ignore list. 