### PR TITLE
Added aoflagger / flind finalcutoff

### DIFF
--- a/flint/coadd/linmos.py
+++ b/flint/coadd/linmos.py
@@ -379,7 +379,8 @@ def generate_linmos_parameter_set(
         f"linmos.useweightslog    = true\n"
         f"linmos.weighttype       = Combined\n"
         f"linmos.weightstate      = Inherent\n"
-        f"linmos.cutoff           = 0.0,{cutoff}\n"
+        f"linmos.cutoff           = {cutoff}\n"
+        f"linmos.finalcutoff           = 0.01\n"
     )
     # Construct the holography section of the linmos parset
     parset += _get_holography_linmos_options(holofile=holofile, pol_axis=pol_axis)

--- a/flint/coadd/linmos.py
+++ b/flint/coadd/linmos.py
@@ -379,7 +379,7 @@ def generate_linmos_parameter_set(
         f"linmos.useweightslog    = true\n"
         f"linmos.weighttype       = Combined\n"
         f"linmos.weightstate      = Inherent\n"
-        f"linmos.cutoff           = {cutoff}\n"
+        f"linmos.cutoff           = 0.0,{cutoff}\n"
     )
     # Construct the holography section of the linmos parset
     parset += _get_holography_linmos_options(holofile=holofile, pol_axis=pol_axis)

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -106,7 +106,8 @@ def task_potato_peel(
 
 @task
 def task_flag_ms_aoflagger(ms: FlagMS, container: Path) -> FlagMS:
-    extracted_ms = MS.cast(ms=ms)  # type: ignore - a product of the type alias, pirate thinks
+    # Pirate believes the type ignore below is due to the decorated function and type alias
+    extracted_ms = MS.cast(ms=ms)  # type: ignore
 
     extracted_ms = flag_ms_aoflagger(ms=extracted_ms, container=container)
 

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -106,7 +106,7 @@ def task_potato_peel(
 
 @task
 def task_flag_ms_aoflagger(ms: FlagMS, container: Path) -> FlagMS:
-    extracted_ms = ms.ms if isinstance(ms, ApplySolutions) else ms
+    extracted_ms = MS.cast(ms=ms)
 
     extracted_ms = flag_ms_aoflagger(ms=extracted_ms, container=container)
 

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -106,7 +106,7 @@ def task_potato_peel(
 
 @task
 def task_flag_ms_aoflagger(ms: FlagMS, container: Path) -> FlagMS:
-    extracted_ms = MS.cast(ms=ms)
+    extracted_ms = MS.cast(ms=ms)  # type: ignore - a product of the type alias, pirate thinks
 
     extracted_ms = flag_ms_aoflagger(ms=extracted_ms, container=container)
 

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -181,6 +181,9 @@ def process_science_fields(
         preprocess_science_mss = task_copy_and_preprocess_casda_askap_ms.map(
             casda_ms=science_mss, output_directory=output_split_science_path
         )
+        preprocess_science_mss = task_flag_ms_aoflagger.map(  # type: ignore
+            ms=preprocess_science_mss, container=field_options.flagger_container
+        )
     else:
         # TODO: This will likely need to be expanded should any
         # other calibration strategies get added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ pandas = "*"
 ConfigArgParse = "^1.7"
 fitscube = "^0.4.3"
 astroquery = "^0.4.7"
+griffe = "0.48.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.3.0"


### PR DESCRIPTION
A couple of unrelated but small changes:
- run aoflagger on casda downloaded measurement sets
- use a new linmos with a `finalcutoff` option