### PR TITLE
Calculate RMS of inner region during validation plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 - removing the `pol` string in the polarisation field of the
   `ProcessedNameComponents`
   - `wclean` output `-` separation character chhanged to `.`
+- The median RMS of the field image is calculated on an inner region when
+  cnnstructing the validation plot
 
 # 0.2.5
 

--- a/flint/coadd/linmos.py
+++ b/flint/coadd/linmos.py
@@ -41,7 +41,8 @@ class BoundingBox(NamedTuple):
 
 
 def create_bound_box(image_data: np.ndarray, is_masked: bool = False) -> BoundingBox:
-    """Construct a bounding box around finite pixels.
+    """Construct a bounding box around finite pixels for a 2D image. This does not
+    support cube type images.
 
     If ``is_mask` is ``False``, the ``image_data`` will be masked internally using ``numpy.isfinite``.
 

--- a/tests/test_linmos_coadd.py
+++ b/tests/test_linmos_coadd.py
@@ -119,6 +119,7 @@ def test_trim_fits_image_matching(tmp_path):
 
 
 def test_bounding_box():
+    """Create a bounding box around a region of valid non-nan/inf pixels"""
     data = np.zeros((1000, 1000))
     data[10:600, 20:500] = 1
     data[data == 0] = np.nan
@@ -132,7 +133,18 @@ def test_bounding_box():
     assert bb.ymax == 499  # slices upper limit no inclusive
 
 
+def test_bounding_box_cube():
+    """Cube cut bounding boxes. Currently not supported."""
+    data = np.zeros((3, 1000, 1000))
+    data[:, 10:600, 20:500] = 1
+    data[data == 0] = np.nan
+
+    with pytest.raises(AssertionError):
+        create_bound_box(image_data=data)
+
+
 def test_bounding_box_with_mask():
+    """Create a bounding box where the input is converted to a boolean arrau"""
     data = np.zeros((1000, 1000))
     data[10:600, 20:500] = 1
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -13,6 +13,7 @@ from flint.validation import (
     RMSImageInfo,
     SourceCounts,
     calculate_area_correction_per_flux,
+    extract_inner_image_array_region,
     get_parser,
     get_rms_image_info,
     get_source_counts,
@@ -46,6 +47,24 @@ def comp_path(tmpdir):
     )
 
     return comp_path
+
+
+def test_extract_inner_image_array_region():
+    """Get the inner region of an image array"""
+    shape = (100, 100)
+    image = np.arange(np.prod(shape)).reshape(shape)
+
+    sub_image = extract_inner_image_array_region(image=image, fraction=0.5)
+    assert sub_image.shape == (50, 50)
+
+    shape = (1, 1, 100, 100)
+    image = np.arange(np.prod(shape)).reshape(shape)
+
+    sub_image = extract_inner_image_array_region(image=image, fraction=0.5)
+    assert sub_image.shape == (1, 1, 50, 50)
+
+    with pytest.raises(AssertionError):
+        extract_inner_image_array_region(image=image, fraction=22.5)
 
 
 def test_plot_source_counts(comp_path, rms_path):
@@ -96,14 +115,16 @@ def test_calculate_area_correction(rms_path):
 def test_rms_image_info(rms_path):
     rms_info = get_rms_image_info(rms_path=rms_path)
 
+    print(rms_info)
+
     assert isinstance(rms_info, RMSImageInfo)
     assert rms_info.path == rms_path
     assert rms_info.no_valid_pixels == 150
     assert rms_info.shape == (10, 15)
-    assert np.isclose(0.0001515522, rms_info.median)
-    assert np.isclose(0.00015135764, rms_info.minimum)
-    assert np.isclose(0.0001518184, rms_info.maximum)
-    assert np.isclose(1.1098655e-07, rms_info.std)
+    assert np.isclose(0.0001515522, rms_info.median, atol=1e-5)
+    assert np.isclose(0.00015135764, rms_info.minimum, atol=1e-5)
+    assert np.isclose(0.0001518184, rms_info.maximum, atol=1e-5)
+    assert np.isclose(1.1098655e-07, rms_info.std, atol=1e-5)
 
 
 class Example(NamedTuple):


### PR DESCRIPTION
When putting a field through the validation plot and table creating a median RMS is computed from the entire RMS computed by bane, which includes the increased in noise towards the edge field as a result of the higher attenuation of the primary beam. 

This introduces a change to extract a set of pixels from the inner region of the RMS image when computing the `RMSImageInfo` structure to avoid this roll off. 