### PR TITLE
Improve CLI for flint_masking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 - cubes are supported when computing the yandasoft linmos weights and trimming
 - `--coadd-cubes` option added to co-add cubes on the final imaging round
   together to form a single field spectral cube
+- Cleaning up the `flint_masking` CLI:
+  - added more options
+  - removed references to butterworth filter
+  - marked `minimum_boxcar)artefact_mask` as deprecated and to be removed
+- Added initial `beam_shape_erode` to masking operations
 
 # 0.2.6
 

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -517,11 +517,8 @@ def _verify_set_positive_seed_clip(
 
 
 def reverse_negative_flood_fill(
+    base_image: np.ndarray,
     masking_options: MaskingOptions,
-    image: Optional[np.ndarray] = None,
-    rms: Optional[np.ndarray] = None,
-    background: Optional[np.ndarray] = None,
-    signal: Optional[np.ndarray] = None,
     pixels_per_beam: Optional[float] = None,
 ) -> np.ndarray:
     """Attempt to:
@@ -549,15 +546,12 @@ def reverse_negative_flood_fill(
     * if there are bright negative artefacts there are likely bright positive artefacts nearby
     * such negative pixels are ~10% level artefacts from a presumed bright sources
 
-    Optionally, the `growlow_snr_mask` may also be considered via the `grow_low_snr` and `grow_low_island_size`
+    Optionally, the `grow_low_snr_mask` may also be considered via the `grow_low_snr` and `grow_low_island_size`
     parameters.
 
     Args:
+        base_image (np.ndarray): The base image or signal map that is used throughout the fill procedure.
         masking_options (MaskingOptions): Options to carry out masking.
-        image (Optional[np.ndarray], optional): The total intensity pixels to have the mask for. Defaults to None.
-        rms (Optional[np.ndarray], optional): The noise across the image. Defaults to None.
-        background (Optional[np.ndarray], optional): The background acros the image. If None, zeros are assumed. Defaults to None.
-        signal(Optional[np.ndarray], optional): A signal map. Defaults to None.
         pixels_per_beam (Optional[float], optional): The number of pixels that cover a beam. Defaults to None.
 
     Returns:
@@ -567,18 +561,14 @@ def reverse_negative_flood_fill(
     logger.info("Will be reversing flood filling")
     logger.info(f"{masking_options=} ")
 
-    signal = _get_signal_image(
-        image=image, rms=rms, background=background, signal=signal
-    )
-
-    if masking_options.flood_fill_use_mbc and image is not None:
+    if masking_options.flood_fill_use_mbc:
         positive_mask = minimum_absolute_clip(
-            image=image,
+            image=base_image,
             increase_factor=masking_options.flood_fill_positive_seed_clip,
             box_size=masking_options.flood_fill_use_mbc_box_size,
         )
         flood_floor_mask = minimum_absolute_clip(
-            image=image,
+            image=base_image,
             increase_factor=masking_options.flood_fill_positive_flood_clip,
             box_size=masking_options.flood_fill_use_mbc_box_size,
         )
@@ -586,13 +576,13 @@ def reverse_negative_flood_fill(
         # Sanity check the upper clip level, you rotten seadog
         positive_seed_clip = _verify_set_positive_seed_clip(
             positive_seed_clip=masking_options.flood_fill_positive_seed_clip,
-            signal=signal,
+            signal=base_image,
         )
         # Here we create the mask image that will start the binary dilation
         # process, and we will ensure only pixels above the `positive_flood_clip`
         # are allowed to be dilated. In other words we are growing the mask
-        positive_mask = signal >= positive_seed_clip
-        flood_floor_mask = signal > masking_options.flood_fill_positive_flood_clip
+        positive_mask = base_image >= positive_seed_clip
+        flood_floor_mask = base_image > masking_options.flood_fill_positive_flood_clip
 
     positive_dilated_mask = scipy_binary_dilation(
         input=positive_mask,
@@ -603,7 +593,7 @@ def reverse_negative_flood_fill(
 
     if masking_options.minimum_boxcar:
         positive_dilated_mask = minimum_boxcar_artefact_mask(
-            signal=signal,
+            signal=base_image,
             island_mask=positive_dilated_mask,
             boxcar_size=masking_options.minimum_boxcar_size,
             increase_factor=masking_options.minimum_boxcar_increase_factor,
@@ -612,7 +602,7 @@ def reverse_negative_flood_fill(
     negative_dilated_mask = None
     if masking_options.suppress_artefacts:
         negative_dilated_mask = suppress_artefact_mask(
-            signal=signal,
+            signal=base_image,
             negative_seed_clip=masking_options.suppress_artefacts_negative_seed_clip,
             guard_negative_dilation=masking_options.suppress_artefacts_guard_negative_dilation,
             pixels_per_beam=pixels_per_beam,
@@ -624,7 +614,7 @@ def reverse_negative_flood_fill(
 
     if masking_options.grow_low_snr_island:
         low_snr_mask = grow_low_snr_mask(
-            signal=signal,
+            signal=base_image,
             grow_low_snr=masking_options.grow_low_snr_island_clip,
             grow_low_island_size=masking_options.grow_low_snr_island_size,
             region_mask=negative_dilated_mask,
@@ -634,17 +624,57 @@ def reverse_negative_flood_fill(
     return positive_dilated_mask.astype(np.int32)
 
 
+def _create_signal_from_rmsbkg(
+    image: Union[Path, np.ndarray],
+    rms: Union[Path, np.ndarray],
+    bkg: Union[Path, np.ndarray],
+) -> np.ndarray:
+    logger.info("Creating signal image")
+
+    if isinstance(image, Path):
+        with fits.open(image) as in_fits:
+            logger.info(f"Loading {image}")
+            image = in_fits[0].data  # type: ignore
+
+    assert isinstance(
+        image, np.ndarray
+    ), f"Expected the image to be a numpy array by now, instead have {type(image)}"
+
+    if isinstance(bkg, Path):
+        with fits.open(bkg) as in_fits:
+            logger.info(f"Loading {bkg=}")
+            bkg = in_fits[0].data  # type: ignore
+
+    logger.info("Subtracting background")
+    image -= bkg
+
+    if isinstance(rms, Path):
+        with fits.open(rms) as in_fits:
+            logger.info(f"Loading {rms=}")
+            rms = in_fits[0].data  # type: ignore
+
+    logger.info("Dividing by rms")
+    image /= rms
+
+    return np.array(image)
+
+
+def _need_to_make_signal(masking_options: MaskingOptions) -> bool:
+    """Isolated functions to consider whether a signal image is needed"""
+    return not masking_options.flood_fill_use_mbc
+
+
 def create_snr_mask_from_fits(
     fits_image_path: Path,
-    fits_rms_path: Path,
-    fits_bkg_path: Path,
     masking_options: MaskingOptions,
+    fits_rms_path: Optional[Path],
+    fits_bkg_path: Optional[Path],
     create_signal_fits: bool = False,
     overwrite: bool = True,
 ) -> FITSMaskNames:
     """Create a mask for an input FITS image based on a signal to noise given a corresponding pair of RMS and background FITS images.
 
-    Internally the signal image is computed as something akin to:
+    Internally should a signal image be needed it is computed as something akin to:
     > signal = (image - background) / rms
 
     This is done in a staged manner to minimise the number of (potentially large) images
@@ -653,13 +683,15 @@ def create_snr_mask_from_fits(
     Each of the input images needs to share the same shape. This means that compression
     features offered by some tooling (e.g. BANE --compress) can not be used.
 
+    Depending on the `MaksingOptions` used the signal image may not be needed.
+
     Once the signal map as been computed, all pixels below ``min_snr`` are flagged.
 
     Args:
         fits_image_path (Path): Path to the FITS file containing an image
-        fits_rms_path (Path): Path to the FITS file with an RMS image corresponding to ``fits_image_path``
-        fits_bkg_path (Path): Path to the FITS file with an baclground image corresponding to ``fits_image_path``
         masking_options (MaskingOptions): Configurables on the masking operation procedure.
+        fits_rms_path (Optional[Path], optional): Path to the FITS file with an RMS image corresponding to ``fits_image_path``. Defaults to None.
+        fits_bkg_path (Optional[Path], optional): Path to the FITS file with an background image corresponding to ``fits_image_path``. Defaults to None.
         create_signal_fits (bool, optional): Create an output signal map. Defaults to False.
         overwrite (bool): Passed to `fits.writeto`, and will overwrite files should they exist. Defaults to True.
 
@@ -675,22 +707,22 @@ def create_snr_mask_from_fits(
         fits_header = fits_image[0].header  # type: ignore
         signal_data = fits_image[0].data  # type: ignore
 
-    with fits.open(fits_bkg_path) as fits_bkg:
-        logger.info("Subtracting background")
-        signal_data -= fits_bkg[0].data  # type: ignore
-
-    with fits.open(fits_rms_path) as fits_rms:
-        logger.info("Dividing by RMS")
-        signal_data /= fits_rms[0].data  # type: ignore
-
-    if create_signal_fits:
-        logger.info(f"Writing {mask_names.signal_fits}")
-        fits.writeto(
-            filename=mask_names.signal_fits,
-            data=signal_data,
-            header=fits_header,
-            overwrite=overwrite,
+    if _need_to_make_signal(masking_options=masking_options):
+        assert isinstance(fits_rms_path, Path) and isinstance(
+            fits_bkg_path, Path
+        ), "Expected paths for input RMS and bkg FITS files"
+        signal_data = _create_signal_from_rmsbkg(
+            image=signal_data, rms=fits_rms_path, bkg=fits_bkg_path
         )
+
+        if create_signal_fits:
+            logger.info(f"Writing {mask_names.signal_fits}")
+            fits.writeto(
+                filename=mask_names.signal_fits,
+                data=signal_data,
+                header=fits_header,
+                overwrite=overwrite,
+            )
 
     pixels_per_beam = get_pixels_per_beam(fits_path=fits_image_path)
 
@@ -704,8 +736,7 @@ def create_snr_mask_from_fits(
         # TODO: The image and signal masks both don't need to be inputs. Image is only used
         # if mbc = True
         mask_data = reverse_negative_flood_fill(
-            signal=np.squeeze(signal_data),
-            image=np.squeeze(fits.getdata(fits_image_path)),
+            base_image=np.squeeze(signal_data),
             masking_options=masking_options,
             pixels_per_beam=pixels_per_beam,
         )
@@ -743,14 +774,14 @@ def get_parser() -> ArgumentParser:
 
     fits_parser = subparser.add_parser(
         "mask",
-        help="Create a mask for an image, using its RMS and BKG images (e.g. outputs from BANE). Output FITS image will default to the image with a mask suffix.",
+        help="Create a mask for an image, potentially using its RMS and BKG images (e.g. outputs from BANE). Output FITS image will default to the image with a mask suffix.",
     )
     fits_parser.add_argument("image", type=Path, help="Path to the input image. ")
     fits_parser.add_argument(
-        "rms", type=Path, help="Path to the RMS of the input image. "
+        "--rms-fits", type=Path, help="Path to the RMS of the input image. "
     )
     fits_parser.add_argument(
-        "bkg", type=Path, help="Path to the BKG of the input image. "
+        "--bkg-fits", type=Path, help="Path to the BKG of the input image. "
     )
 
     fits_parser.add_argument(
@@ -852,8 +883,8 @@ def cli():
         masking_options = _args_to_mask_options(args=args)
         create_snr_mask_from_fits(
             fits_image_path=args.image,
-            fits_rms_path=args.rms,
-            fits_bkg_path=args.bkg,
+            fits_rms_path=args.rms_fits,
+            fits_bkg_path=args.bkg_fits,
             create_signal_fits=args.save_signal,
             masking_options=masking_options,
         )

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -670,11 +670,14 @@ def create_snr_mask_from_fits(
         fits_image=fits_image_path, include_signal_path=create_signal_fits
     )
 
+    # TODOL Make the bkg and rms images optional. Don't need to load if mbc is usede
     with fits.open(fits_image_path) as fits_image:
         fits_header = fits_image[0].header  # type: ignore
-        with fits.open(fits_bkg_path) as fits_bkg:
-            logger.info("Subtracting background")
-            signal_data = fits_image[0].data - fits_bkg[0].data  # type: ignore
+        signal_data = fits_image[0].data  # type: ignore
+
+    with fits.open(fits_bkg_path) as fits_bkg:
+        logger.info("Subtracting background")
+        signal_data -= fits_bkg[0].data  # type: ignore
 
     with fits.open(fits_rms_path) as fits_rms:
         logger.info("Dividing by RMS")
@@ -698,7 +701,8 @@ def create_snr_mask_from_fits(
     # case of a fits file, the file may either contain a single frequency or it may
     # contain a cube of images.
     if masking_options.flood_fill:
-        # TODO: This function should really just accept a MaskingOptions directly
+        # TODO: The image and signal masks both don't need to be inputs. Image is only used
+        # if mbc = True
         mask_data = reverse_negative_flood_fill(
             signal=np.squeeze(signal_data),
             image=np.squeeze(fits.getdata(fits_image_path)),

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -185,11 +185,16 @@ def beam_shape_erode(
         fits_header=fits_header, minimum_response=minimum_response
     )
 
+    # This handles any unsqueezed dimensions
+    beam_mask_kernel = beam_mask_kernel.reshape(
+        mask.shape[:-2] + beam_mask_kernel.shape
+    )
+
     erode_mask = scipy_binary_erosion(
         input=mask, iterations=1, structure=beam_mask_kernel
     )
 
-    return erode_mask
+    return erode_mask.astype(mask.dtype)
 
 
 def extract_beam_mask_from_mosaic(
@@ -879,7 +884,7 @@ def cli():
 
     args = parser.parse_args()
 
-    if args.mode == "snrmask":
+    if args.mode == "mask":
         masking_options = _args_to_mask_options(args=args)
         create_snr_mask_from_fits(
             fits_image_path=args.image,

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -109,7 +109,7 @@ def consider_beam_mask_round(
     )  # type: ignore
 
 
-def make_beam_msk_kernel(
+def make_beam_mask_kernel(
     fits_header: fits.Header, kernel_size=100, minimum_response: float = 0.6
 ) -> np.ndarray:
     """Make a mask using the shape of a beam in a FITS Header object. The

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -134,7 +134,9 @@ def create_beam_mask_kernel(
     Returns:
         np.ndarray: Boolean mask of the kernel shape
     """
-    assert minimum_response > 0, f"{minimum_response=}, should be positive"
+    assert (
+        0.0 < minimum_response < 1.0
+    ), f"{minimum_response=}, should be between 0 to 1 (exclusive)"
 
     POSITION_KEYS = ("CDELT1", "CDELT2")
     if not all([key in fits_header for key in POSITION_KEYS]):
@@ -180,7 +182,7 @@ def beam_shape_erode(
         )
         return mask
 
-    logger.info("Eroding the mask using the beam shape")
+    logger.info(f"Eroding the mask using the beam shape with {minimum_response=}")
     beam_mask_kernel = create_beam_mask_kernel(
         fits_header=fits_header, minimum_response=minimum_response
     )
@@ -841,7 +843,7 @@ def get_parser() -> ArgumentParser:
         "--beam-shape-erode-minimum-response",
         type=float,
         default=0.6,
-        help="The minimum response of the beam that is used to form t he erode structure shape",
+        help="The minimum response of the beam that is used to form t he erode structure shape. Smaller numbers correspond to a larger shape which means islands are more aggressively removed",
     )
 
     extract_parser = subparser.add_parser(

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -816,7 +816,6 @@ def _create_convolve_linmos_cubes(
 def task_create_image_mask_model(
     image: Union[LinmosCommand, ImageSet, WSCleanCommand],
     image_products: AegeanOutputs,
-    min_snr: Optional[float] = 3.5,
     update_masking_options: Optional[Dict[str, Any]] = None,
 ) -> FITSMaskNames:
     """Create a mask from a linmos image, with the intention of providing it as a clean mask
@@ -825,7 +824,6 @@ def task_create_image_mask_model(
     Args:
         linmos_parset (LinmosCommand): Linmos command and associated meta-data
         image_products (AegeanOutputs): Images of the RMS and BKG
-        min_snr (float, optional): The minimum S/N a pixel should be for it to be included in the clean mask.
         update_masking_options (Optional[Dict[str,Any]], optional): Updated options supplied to the default MaskingOptions. Defaults to None.
 
 

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -400,7 +400,6 @@ def process_science_fields(
                 fits_beam_masks = task_create_image_mask_model.map(
                     image=wsclean_cmds,
                     image_products=beam_aegean_outputs,
-                    min_snr=3.5,
                     update_masking_options=unmapped(masking_options),
                 )
 

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -89,6 +89,26 @@ def test_beam_shape_erode():
     assert np.sum(erode_mask) == 729
 
 
+def test_beam_shape_erode_nobeam():
+    """Ensure that the beam shape erosion approach works. This should drop out pixels
+    should the beam shape structure connectivity be statisifed. This should simply return
+    the input array since there is no beam information"""
+    fits_header = fits.Header(
+        dict(
+            CDELT1=-0.000694444444444444,
+            CDELT2=0.000694444444444444,
+        )
+    )
+
+    mask = np.zeros((500, 500)).astype(bool)
+
+    mask[300, 300] = True
+    assert np.sum(mask) == 1
+    new_mask = beam_shape_erode(mask=mask, fits_header=fits_header)
+    assert new_mask is mask
+    assert np.sum(new_mask) == 1
+
+
 def test_consider_beam_masking_round():
     """Test to ensure the beam mask consideration log is correct"""
     lower = ("all", "ALL", "aLl")


### PR DESCRIPTION
Some interest has been received around using some of the masking operations for use via a cli. Upon inspection it was pretty clear the cli was out of date and fairly primitive. 

This change improves the CLI, and marks an early version of the minimum box car artifact masker as deprecated and to be removed. 

A separate erosion mode based on the shape of the restoring beam has also been added. 

Some other bits of dead code has been removed, and some light reordering of the internals / keyword parameters. 

Tests have been added for some of the new features, and some have been modified in anticipation of removing the older minimum box car artifact masker. 