### PR TITLE
Remove old masking modes, add adaptive mode to mbc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Added a verify tarball function to verify archives
 - Removed `suppress_artefact` and `minimum_absolute_clip` functions from
   `flint.masking`
--
+- Added an adaptive box selection mode to the minimum absolute algorithm
 
 # 0.2.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   - load arguments into an `BaseOptions` class from a `ArgumentParser`
   - starting to move some classes over to this approaches (including some CLIs)
 - Added a verify tarball function to verify archives
+- Removed `suppress_artefact` and `minimum_absolute_clip` functions from
+  `flint.masking`
+-
 
 # 0.2.7
 

--- a/flint/data/tests/test_config.yaml
+++ b/flint/data/tests/test_config.yaml
@@ -54,9 +54,6 @@ defaults:
     flood_fill: true
     flood_fill_positive_seed_clip: 4.5
     flood_fill_positive_flood_clip: 1.5
-    suppress_artefacts: true
-    suppress_artefacts_negative_seed_clip: 5
-    suppress_artefacts_guard_negative_dilation: 40
     grow_low_snr_island: true
     grow_low_snr_island_clip: 1.75
     grow_low_snr_island_size: 768

--- a/flint/data/tests/test_config_2.yaml
+++ b/flint/data/tests/test_config_2.yaml
@@ -54,9 +54,6 @@ defaults:
     flood_fill: true
     flood_fill_positive_seed_clip: 4.5
     flood_fill_positive_flood_clip: 1.5
-    suppress_artefacts: true
-    suppress_artefacts_negative_seed_clip: 5
-    suppress_artefacts_guard_negative_dilation: 40
     grow_low_snr_island: true
     grow_low_snr_island_clip: 1.75
     grow_low_snr_island_size: 768

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -755,7 +755,6 @@ def get_parser() -> ArgumentParser:
     )
     fits_parser.add_argument(
         "--save-signal",
-        type=bool,
         action="store_true",
         help="Save the signal image internally generated (should it be generated)",
     )

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -753,6 +753,12 @@ def get_parser() -> ArgumentParser:
     fits_parser.add_argument(
         "--bkg-fits", type=Path, help="Path to the BKG of the input image. "
     )
+    fits_parser.add_argument(
+        "--save-signal",
+        type=bool,
+        action="store_true",
+        help="Save the signal image internally generated (should it be generated)",
+    )
 
     extract_parser = subparser.add_parser(
         "extractmask",

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -554,6 +554,9 @@ def reverse_negative_flood_fill(
             image=base_image,
             increase_factor=masking_options.flood_fill_positive_seed_clip,
             box_size=masking_options.flood_fill_use_mbc_box_size,
+            adaptive_max_depth=masking_options.flood_fill_use_mbc_adaptive_max_depth,
+            adaptive_box_step=masking_options.flood_fill_use_mbc_adative_step_factor,
+            adaptive_skew_delta=masking_options.flood_fill_use_mbc_adaptive_skew_delta,
         )
         flood_floor_mask = minimum_absolute_clip(
             image=base_image,

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -562,6 +562,9 @@ def reverse_negative_flood_fill(
             image=base_image,
             increase_factor=masking_options.flood_fill_positive_flood_clip,
             box_size=masking_options.flood_fill_use_mbc_box_size,
+            adaptive_max_depth=masking_options.flood_fill_use_mbc_adaptive_max_depth,
+            adaptive_box_step=masking_options.flood_fill_use_mbc_adaptive_step_factor,
+            adaptive_skew_delta=masking_options.flood_fill_use_mbc_adaptive_skew_delta,
         )
     else:
         # Sanity check the upper clip level, you rotten seadog

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -555,7 +555,7 @@ def reverse_negative_flood_fill(
             increase_factor=masking_options.flood_fill_positive_seed_clip,
             box_size=masking_options.flood_fill_use_mbc_box_size,
             adaptive_max_depth=masking_options.flood_fill_use_mbc_adaptive_max_depth,
-            adaptive_box_step=masking_options.flood_fill_use_mbc_adative_step_factor,
+            adaptive_box_step=masking_options.flood_fill_use_mbc_adaptive_step_factor,
             adaptive_skew_delta=masking_options.flood_fill_use_mbc_adaptive_skew_delta,
         )
         flood_floor_mask = minimum_absolute_clip(

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -49,7 +49,7 @@ class MaskingOptions(BaseOptions):
     """If True, the clipping levels are used as the `increase_factor` when using a minimum absolute clip"""
     flood_fill_use_mbc_box_size: int = 75
     """The size of the mbc box size should mbc be used"""
-    flood_fill_use_mbc_adative_step_factor: float = 2.0
+    flood_fill_use_mbc_adaptive_step_factor: float = 2.0
     """Stepping size used to increase box by should adaptive detect poor boxcar statistics"""
     flood_fill_use_mbc_adaptive_skew_delta: float = 0.2
     """A box is consider too small for a pixel if the fractional proportion of positive pixels is larger than the deviation away of (0.5 + frac). This threshold is therefore 0 to 0.5"""

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -414,6 +414,9 @@ def _adaptive_minimum_absolute_clip(
         if np.all(~skew_results.skew_mask):
             logger.info("No skewed islands detected")
             break
+        if any([box_size > dim for dim in image.shape]):
+            logger.info(f"{box_size=} larger than a dimension in {image.shape=}")
+            break
 
         logger.info(f"({box_round}) Growing {box_size=} {adaptive_box_step=}")
         box_size = int(box_size * adaptive_box_step)

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -16,33 +16,71 @@ from flint.masking import (
     create_snr_mask_from_fits,
     get_parser,
     _minimum_absolute_clip,
+    minimum_absolute_clip,
 )
 from flint.naming import FITSMaskNames
 
 SHAPE = (100, 100)
 
 
-def test_minimum_absolute_clip():
+def test_adaptive_minimum_absolute_clip():
+    """Activate the adaptive mode of the mac"""
+
+    image = np.ones((2000, 2000)) * -1.2
+    image[100:200, 100:200] = 1.0
+    mask = minimum_absolute_clip(
+        image=image,
+        box_size=50,
+        increase_factor=1.1,
+        adaptive_max_depth=1,
+        adaptive_box_step=4.0,
+        adaptive_skew_delta=0.2,
+    )
+    assert np.all(~mask)
+
+    image = np.ones((2000, 2000)) * -1.2
+    image[100:200, 100:200] = 1.0
+    image[110, 130] = 2000
+    mask = minimum_absolute_clip(
+        image=image,
+        box_size=50,
+        increase_factor=1.1,
+        adaptive_max_depth=1,
+        adaptive_box_step=4.0,
+        adaptive_skew_delta=0.2,
+    )
+    assert np.sum(mask) == 1
+
+
+def test_private_minimum_absolute_clip():
     """The minimum absolute clipping process accepts an image
     and returns a mask.  At its heart it applies a ``minimum_filter``
     from scipy."""
 
     image = np.ones(SHAPE) * -1.0
     image[10, 10] = -2
-    mbc_mask = _minimum_absolute_clip(image=image, box_size=10)
+    private_mbc_mask = _minimum_absolute_clip(image=image, box_size=10)
+    mbc_mask = minimum_absolute_clip(image=image, box_size=10)
     assert np.all(~mbc_mask)
+    assert np.all(private_mbc_mask == mbc_mask)
 
     image[12, 12] = 5
-    mbc_mask = _minimum_absolute_clip(image=image)
+    private_mbc_mask = _minimum_absolute_clip(image=image)
+    mbc_mask = minimum_absolute_clip(image=image)
     assert np.sum(mbc_mask) == 1
+    assert np.all(private_mbc_mask == mbc_mask)
 
     image[12, 12] = 0
-    mbc_mask = _minimum_absolute_clip(image=image)
+    private_mbc_mask = _minimum_absolute_clip(image=image)
+    mbc_mask = minimum_absolute_clip(image=image)
     assert np.all(~mbc_mask)
+    assert np.all(private_mbc_mask == mbc_mask)
 
     image[12, 12] = 5
-    mbc_mask = _minimum_absolute_clip(image=image, increase_factor=3)
+    private_mbc_mask = _minimum_absolute_clip(image=image, increase_factor=3)
+    mbc_mask = minimum_absolute_clip(image=image, increase_factor=3)
     assert np.all(~mbc_mask)
+    assert np.all(private_mbc_mask == mbc_mask)
 
 
 def test_create_signal_from_rmsbkg():

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -15,7 +15,6 @@ from flint.masking import (
     create_options_from_parser,
     create_snr_mask_from_fits,
     get_parser,
-    minimum_boxcar_artefact_mask,
 )
 from flint.naming import FITSMaskNames
 
@@ -196,66 +195,6 @@ def test_consider_beam_masking_round():
         current_round=3, mask_rounds=1, allow_beam_masks=True
     )
     assert consider_beam_mask_round(current_round=1, mask_rounds=1)
-
-
-def test_minimum_boxcar_artefact():
-    """See if the minimum box care artefact suppressor can suppress the
-    bright artefact when a bright negative artefact
-    """
-    img = np.zeros((SHAPE))
-
-    img[30:40, 30:40] = 10
-    img_mask = img > 5
-
-    out_mask = minimum_boxcar_artefact_mask(
-        signal=img, island_mask=img_mask, boxcar_size=10
-    )
-    assert np.all(img_mask == out_mask)
-    assert out_mask is img_mask  # minimum boxcar artefact mask to be deprecated
-    # assert img_mask is not out_mask
-
-    img[41:45, 30:40] = -20
-    out_mask = minimum_boxcar_artefact_mask(
-        signal=img, island_mask=img_mask, boxcar_size=10
-    )
-    assert out_mask is img_mask  # minimum boxcar artefact mask to be deprecated
-
-    # assert not np.all(img_mask == out_mask)
-
-
-def test_minimum_boxcar_artefact_blanked():
-    """See if the minimum box care artefact suppressor can suppress the
-    bright artefact when a bright negative artefact
-    """
-    img = np.zeros((SHAPE))
-
-    img[30:40, 30:40] = 10
-    img[41:45, 30:40] = -20
-
-    img_mask = img > 5
-
-    out_mask = minimum_boxcar_artefact_mask(
-        signal=img, island_mask=img_mask, boxcar_size=10, increase_factor=1000
-    )
-    assert out_mask is img_mask  # minimum boxcar artefact mask will be deprecated
-
-    # assert out_mask is not img_mask
-    # assert np.all(out_mask[30:40, 30:40] == False)  # noqa
-
-
-def test_minimum_boxcar_large_bright_island():
-    """This one checks to make sure that if the boxcar is smaller than
-    a positive islane that the island is not the island_min
-    """
-
-    img = np.zeros(SHAPE)
-    img[30:40, 30:40] = 10
-    img_mask = img > 5
-
-    out_mask = minimum_boxcar_artefact_mask(
-        signal=img, island_mask=img_mask, boxcar_size=2
-    )
-    assert np.all(img_mask == out_mask)
 
 
 @pytest.fixture

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -15,10 +15,34 @@ from flint.masking import (
     create_options_from_parser,
     create_snr_mask_from_fits,
     get_parser,
+    _minimum_absolute_clip,
 )
 from flint.naming import FITSMaskNames
 
 SHAPE = (100, 100)
+
+
+def test_minimum_absolute_clip():
+    """The minimum absolute clipping process accepts an image
+    and returns a mask.  At its heart it applies a ``minimum_filter``
+    from scipy."""
+
+    image = np.ones(SHAPE) * -1.0
+    image[10, 10] = -2
+    mbc_mask = _minimum_absolute_clip(image=image, box_size=10)
+    assert np.all(~mbc_mask)
+
+    image[12, 12] = 5
+    mbc_mask = _minimum_absolute_clip(image=image)
+    assert np.sum(mbc_mask) == 1
+
+    image[12, 12] = 0
+    mbc_mask = _minimum_absolute_clip(image=image)
+    assert np.all(~mbc_mask)
+
+    image[12, 12] = 5
+    mbc_mask = _minimum_absolute_clip(image=image, increase_factor=3)
+    assert np.all(~mbc_mask)
 
 
 def test_create_signal_from_rmsbkg():


### PR DESCRIPTION
Some old masking modes have been removed. They have largely been replaced by the minimum absolute clip. 

An adaptive mode to the boxcar in the MAC has been added. It is based on an idea of balancing the number of positive to negative pixels within a box. 