### PR TITLE
Set up and use -save-source-list and addmodel for predicting at full channel resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Removed `suppress_artefact` and `minimum_absolute_clip` functions from
   `flint.masking`
 - Added an adaptive box selection mode to the minimum absolute algorithm
+- Update a MSs `MODEL_DATA` column using `addmodel` and a source list (see
+  `wsclean -save-source-list`)
 
 # 0.2.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Added an adaptive box selection mode to the minimum absolute algorithm
 - Update a MSs `MODEL_DATA` column using `addmodel` and a source list (see
   `wsclean -save-source-list`)
+- Added a `taql` based function intended to be used to subtract model data from
+  nominated data, `flint.ms.subtract_model_from_data_column`
 
 # 0.2.7
 

--- a/flint/calibrate/aocalibrate.py
+++ b/flint/calibrate/aocalibrate.py
@@ -1108,6 +1108,17 @@ def add_model_options_to_command(add_model_options: AddModelOptions) -> str:
 def add_model(
     add_model_options: AddModelOptions, container: Path, remove_datacolumn: bool = False
 ) -> AddModelOptions:
+    """Use the ``addmodel`` program to predict the sky-model visibilities
+    from a compatible source list (e.g. ``wsclean -save-source-list``)
+
+    Args:
+        add_model_options (AddModelOptions): The set of supported options to be supplied to ``addmodel``
+        container (Path): The calibrate container that contains the ``addmodel`` program
+        remove_datacolumn (bool, optional): Whether to first removed the ``datacolumn`` specified in ``add_model_options`` before predicting. If False it should be overwritten. Defaults to False.
+
+    Returns:
+        AddModelOptions: The options used to run ``addmodel`` (same as input)
+    """
     if remove_datacolumn:
         remove_columns_from_ms(
             ms=add_model_options.ms_path, columns_to_remove=add_model_options.datacolumn

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -44,7 +44,7 @@ from flint.utils import (
 )
 
 
-class ImageSet(NamedTuple):
+class ImageSet(BaseOptions):
     """A structure to represent the images and auxiliary products produced by
     wsclean"""
 

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -815,7 +815,11 @@ def run_wsclean_imager(
             mode="c",
             datacolumn="MODEL_DATA",
         )
-        add_model(add_model_options=add_model_options, container=calibrate_container)
+        add_model(
+            add_model_options=add_model_options,
+            container=calibrate_container,
+            remove_datacolumn="MODEL_DATA",
+        )
 
     imageset = get_wsclean_output_names(
         prefix=prefix,

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -156,6 +156,8 @@ class WSCleanOptions(BaseOptions):
     """The path to a temporary directory where files will be wrritten. """
     pol: str = "i"
     """The polarisation to be imaged"""
+    save_source_list: bool = False
+    """Saves the found clean components as a BBS/DP3 text sky model"""
 
 
 class WSCleanCommand(NamedTuple):

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -806,7 +806,7 @@ def run_wsclean_imager(
     if calibrate_container and wsclean_cmd.options.save_source_list:
         logger.info("Predicting the wsclean clean components SEDs")
         source_list_path = get_wsclean_output_source_list_path(
-            name_path=prefix, pol="i"
+            name_path=prefix, pol=None
         )
         assert source_list_path.exists(), f"{source_list_path=} does not exist"
         add_model_options = AddModelOptions(

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -177,7 +177,7 @@ class WSCleanCommand(BaseOptions):
 
 
 def get_wsclean_output_source_list_path(
-    name_path: Union[str, Path], pol: str = "i"
+    name_path: Union[str, Path], pol: Optional[str] = None
 ) -> Path:
     """WSClean can produce a text file that describes the components
     that it cleaned, their type, scale and brightness. These are
@@ -192,7 +192,7 @@ def get_wsclean_output_source_list_path(
 
     Args:
         name_path (Union[str,Path]): Value of the ``-name`` option. If `str` converted to a ``Path``
-        pol (str, optional): The polarisation to add to the name. Defaults to "i".
+        pol (Optional[str], optional): The polarisation to add to the name. If None the -source.txt suffix is simply appended. Defaults to None.
 
     Returns:
         Path: Path to the source list text file
@@ -206,7 +206,9 @@ def get_wsclean_output_source_list_path(
 
     logger.info(f"{base_name=} extracted from {name_path=}")
 
-    source_list_name = f"{base_name}.{pol}-sources.txt"
+    source_list_name = (
+        f"{base_name}.{pol}-sources.txt" if pol else f"{base_name}-sources.txt"
+    )
     source_list_path = name_path.parent / source_list_name
 
     return source_list_path
@@ -330,7 +332,7 @@ def get_wsclean_output_names(
     if isinstance(output_types, str):
         output_types = (output_types,)
 
-    images: Dict[str, Collection[Path]] = {}
+    images: Dict[str, List[Path]] = {}
     for image_type in ("image", "dirty", "model", "residual"):
         if image_type not in output_types:
             continue

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -181,6 +181,40 @@ class WSCleanCommand(NamedTuple):
         return WSCleanCommand(**_dict)
 
 
+def get_wsclean_output_source_list_path(name_path: Path, pol: str = "i") -> Path:
+    """WSClean can produce a text file that describes the components
+    that it cleaned, their type, scale and brightness. These are
+    placed in a file that is:
+
+    >> {name}.{pol}-sources.txt
+
+    where ``name`` represented the `-name` component. Given
+    an input measurement set path or this `-name` value return
+    the expected source list text file. ``pol`` is the stokes
+    that the source is expected.
+
+    Args:
+        name_path (Path): Value of the ``-name`` option. If `str` converted to a ``Path``
+        pol (str, optional): The polarisation to add to the name. Defaults to "i".
+
+    Returns:
+        Path: Path to the source list text file
+    """
+
+    # ye not be trusted
+    name_path = Path(name_path)
+    base_name = name_path.name
+    if ".ms" == Path(base_name).suffix:
+        base_name = Path(base_name).stem
+
+    logger.info(f"{base_name=} extracted from {name_path=}")
+
+    source_list_name = f"{base_name}.{pol}-sources.txt"
+    source_list_path = name_path.parent / source_list_name
+
+    return source_list_path
+
+
 def _rename_wsclean_title(name_str: str) -> str:
     """Construct an apply a regular expression that aims to identify
     the wsclean appended properties string within a file and replace

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -51,15 +51,15 @@ class ImageSet(NamedTuple):
 
     prefix: str
     """Prefix of the images and other output products. This should correspond to the -name argument from wsclean"""
-    image: Collection[Path]
+    image: List[Path]
     """Images produced. """
-    psf: Optional[Collection[Path]] = None
+    psf: Optional[List[Path]] = None
     """References to the PSFs produced by wsclean. """
-    dirty: Optional[Collection[Path]] = None
+    dirty: Optional[List[Path]] = None
     """Dirty images. """
-    model: Optional[Collection[Path]] = None
+    model: Optional[List[Path]] = None
     """Model images.  """
-    residual: Optional[Collection[Path]] = None
+    residual: Optional[List[Path]] = None
     """Residual images."""
 
 

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -525,7 +525,6 @@ def create_wsclean_cmd(
     ms: MS,
     wsclean_options: WSCleanOptions,
     container: Optional[Path] = None,
-    calibrate_container: Optional[Path] = None,
 ) -> WSCleanCommand:
     """Create a wsclean command from a WSCleanOptions container
 
@@ -542,7 +541,6 @@ def create_wsclean_cmd(
         ms (MS): The measurement set to be imaged
         wsclean_options (WSCleanOptions): WSClean options to image with
         container (Optional[Path], optional): If a path to a container is provided the command is executed immediately. Defaults to None.
-        calibrate_container (Optional[Path], optional): Patht to the aocalibrate container with ``addmodel``. If not None and ``wsclean -save-source-list` is used the model will be predicted at full channel resolution
 
     Raises:
         ValueError: Raised when a option has not been successfully processed
@@ -604,7 +602,6 @@ def create_wsclean_cmd(
             bind_dirs=tuple(bind_dir_paths),
             move_hold_directories=(move_directory, hold_directory),
             image_prefix_str=str(name_argument_path),
-            calibrate_container=calibrate_container,
         )
 
     return wsclean_cmd

--- a/flint/ms.py
+++ b/flint/ms.py
@@ -543,6 +543,36 @@ def rename_column_in_ms(
     return ms
 
 
+def remove_columns_from_ms(
+    ms: Union[MS, Path], columns_to_remove: Union[str, List[str]]
+) -> List[str]:
+    """Attempt to remove a collection of columns from a measurement set.
+    If any of the provided columns do not exist they are ignored.
+
+    Args:
+        ms (Union[MS, Path]): The measurement set to inspect and remove columns from
+        columns_to_remove (Union[str, List[str]]): Collection of column names to remove. If a single column internally it is cast to a list of length 1.
+
+    Returns:
+        List[str]: Collection of column names removed
+    """
+
+    if isinstance(columns_to_remove, str):
+        columns_to_remove = [columns_to_remove]
+
+    ms = MS.cast(ms=ms)
+    with table(tablename=str(ms.path), readonly=False, ack=False) as tab:
+        colnames = tab.colnames()
+        columns_to_remove = [c for c in columns_to_remove if c in colnames]
+        if len(columns_to_remove) == 0:
+            logger.info(f"All columns provided do not exist in {ms.path}")
+        else:
+            logger.info(f"Removing {columns_to_remove=} from {ms.path}")
+            tab.removecols(columnnames=columns_to_remove)
+
+    return columns_to_remove
+
+
 def preprocess_askap_ms(
     ms: Union[MS, Path],
     data_column: str = "DATA",

--- a/flint/ms.py
+++ b/flint/ms.py
@@ -94,7 +94,7 @@ def critical_ms_interaction(
     assert (
         not output_ms.exists()
     ), f"The output measurement set {output_ms} already exists. "
-
+    logger.info(f"Critical section for {input_ms=}")
     if copy:
         rsync_copy_directory(target_path=input_ms, out_path=output_ms)
     else:
@@ -571,6 +571,39 @@ def remove_columns_from_ms(
             tab.removecols(columnnames=columns_to_remove)
 
     return columns_to_remove
+
+
+def subtract_model_from_data_column(
+    ms: MS, model_column: str = "MODEL_DATA", data_column: Optional[str] = None
+) -> MS:
+    """Execute a ``taql`` query to subtract the MODEL_DATA from a nominated data column.
+    This requires the ``model_column`` to already be inserted into the MS. Internally
+    the ``critical_ms_interaction`` context manager is used to highlight that the MS
+    is being modified should things fail when subtracting.
+
+    Args:
+        ms (MS): The measurement set instance being considered
+        model_column (str, optional): The column with representing the model. Defaults to "MODEL_DATA".
+        data_column (Optional[str], optional): The column where the column will be subtracted. If ``None`` it is taken from the ``column`` nominated by the input ``MS`` instance. Defaults to None.
+
+    Returns:
+        MS: The updated MS
+    """
+    ms = MS.cast(ms)
+    data_column = data_column if data_column else ms.column
+    assert data_column is not None, f"{data_column=}, which is not allowed"
+    with critical_ms_interaction(input_ms=ms.path) as critical_ms:
+        with table(str(critical_ms), readonly=False) as tab:
+            logger.info("Extracting columns")
+            colnames = tab.colnames()
+            assert all(
+                [d in colnames for d in (model_column, data_column)]
+            ), f"{model_column=} or {data_column=} missing from {colnames=}"
+
+            logger.info(f"Subtracting {model_column=} from {data_column=}")
+            taql(f"UPDATE $tab SET {data_column}={data_column}-{model_column}")
+
+    return ms
 
 
 def preprocess_askap_ms(

--- a/flint/options.py
+++ b/flint/options.py
@@ -290,6 +290,8 @@ class FieldOptions(BaseOptions):
     """Specifies whether Stokes-V imaging will be carried out after the final round of imagine (whether or not self-calibration is enabled). """
     coadd_cubes: bool = False
     """Co-add cubes formed throughout imaging together. Cubes will be smoothed channel-wise to a common resolution. Only performed on final set of images"""
+    update_model_data_with_source_list: bool = False
+    """Attempt to update a MSs MODEL_DATA column with a source list (e.g. source list output from wsclean)"""
 
 
 def dump_field_options_to_yaml(

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -283,6 +283,7 @@ def task_wsclean_imager(
     wsclean_container: Path,
     update_wsclean_options: Optional[Dict[str, Any]] = None,
     fits_mask: Optional[FITSMaskNames] = None,
+    calibrate_container: Optional[Path] = None,
 ) -> WSCleanCommand:
     """Run the wsclean imager against an input measurement set
 
@@ -291,6 +292,7 @@ def task_wsclean_imager(
         wsclean_container (Path): Path to a singularity container with wsclean packages
         update_wsclean_options (Optional[Dict[str, Any]], optional): Options to update from the default wsclean options. Defaults to None.
         fits_mask (Optional[FITSMaskNames], optional): A path to a clean guard mask. Defaults to None.
+        calibrate_container (Optional[Path], optional): The aocalibrate container that has the ``addmodel`` program. is ``wsclean -save-source-list` is used then the model will be predicted at full resolution
 
     Returns:
         WSCleanCommand: A resulting wsclean command and resulting meta-data
@@ -312,6 +314,7 @@ def task_wsclean_imager(
             ms=ms,
             wsclean_container=wsclean_container,
             update_wsclean_options=update_wsclean_options,
+            calibrate_container=calibrate_container,
         )
     except CleanDivergenceError:
         # NOTE: If the cleaning failed retry with some larger images
@@ -340,6 +343,7 @@ def task_wsclean_imager(
             ms=ms,
             wsclean_container=wsclean_container,
             update_wsclean_options=update_wsclean_options,
+            calibrate_container=calibrate_container,
         )
 
 

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -283,7 +283,6 @@ def task_wsclean_imager(
     wsclean_container: Path,
     update_wsclean_options: Optional[Dict[str, Any]] = None,
     fits_mask: Optional[FITSMaskNames] = None,
-    calibrate_container: Optional[Path] = None,
 ) -> WSCleanCommand:
     """Run the wsclean imager against an input measurement set
 
@@ -292,7 +291,6 @@ def task_wsclean_imager(
         wsclean_container (Path): Path to a singularity container with wsclean packages
         update_wsclean_options (Optional[Dict[str, Any]], optional): Options to update from the default wsclean options. Defaults to None.
         fits_mask (Optional[FITSMaskNames], optional): A path to a clean guard mask. Defaults to None.
-        calibrate_container (Optional[Path], optional): The aocalibrate container that has the ``addmodel`` program. is ``wsclean -save-source-list` is used then the model will be predicted at full resolution
 
     Returns:
         WSCleanCommand: A resulting wsclean command and resulting meta-data
@@ -314,7 +312,6 @@ def task_wsclean_imager(
             ms=ms,
             wsclean_container=wsclean_container,
             update_wsclean_options=update_wsclean_options,
-            calibrate_container=calibrate_container,
         )
     except CleanDivergenceError:
         # NOTE: If the cleaning failed retry with some larger images
@@ -343,7 +340,6 @@ def task_wsclean_imager(
             ms=ms,
             wsclean_container=wsclean_container,
             update_wsclean_options=update_wsclean_options,
-            calibrate_container=calibrate_container,
         )
 
 

--- a/flint/prefect/common/ms.py
+++ b/flint/prefect/common/ms.py
@@ -18,15 +18,19 @@ def add_model_source_list_to_ms(
     logger.info("Updating MODEL_DATA with source list")
     ms = wsclean_command.ms
 
+    assert (
+        wsclean_command.imageset is not None
+    ), f"{wsclean_command.imageset=}, which is not allowed"
+
     source_list_path = wsclean_command.imageset.source_list
     if source_list_path is None:
         logger.info(f"{source_list_path=}, so not updating")
-        return ms
+        return wsclean_command
     assert source_list_path.exists(), f"{source_list_path=} does not exist"
 
     if calibrate_container is None:
         logger.info(f"{calibrate_container=}, so not updating")
-        return ms
+        return wsclean_command
     assert calibrate_container.exists(), f"{calibrate_container=} does not exist"
 
     add_model_options = AddModelOptions(
@@ -38,7 +42,7 @@ def add_model_source_list_to_ms(
     add_model(
         add_model_options=add_model_options,
         container=calibrate_container,
-        remove_datacolumn="MODEL_DATA",
+        remove_datacolumn=True,
     )
     return wsclean_command
 

--- a/flint/prefect/common/ms.py
+++ b/flint/prefect/common/ms.py
@@ -1,0 +1,46 @@
+"""Common prefect tasks around interacting with measurement sets"""
+
+from pathlib import Path
+from typing import Optional
+
+from prefect import task
+
+from flint.calibrate.aocalibrate import AddModelOptions, add_model
+from flint.logging import logger
+from flint.imager.wsclean import WSCleanCommand
+
+
+# TODO: This can be a dispatcher type function should
+# other modes be added
+def add_model_source_list_to_ms(
+    wsclean_command: WSCleanCommand, calibrate_container: Optional[Path] = None
+) -> WSCleanCommand:
+    logger.info("Updating MODEL_DATA with source list")
+    ms = wsclean_command.ms
+
+    source_list_path = wsclean_command.imageset.source_list
+    if source_list_path is None:
+        logger.info(f"{source_list_path=}, so not updating")
+        return ms
+    assert source_list_path.exists(), f"{source_list_path=} does not exist"
+
+    if calibrate_container is None:
+        logger.info(f"{calibrate_container=}, so not updating")
+        return ms
+    assert calibrate_container.exists(), f"{calibrate_container=} does not exist"
+
+    add_model_options = AddModelOptions(
+        model_path=source_list_path,
+        ms_path=ms.path,
+        mode="c",
+        datacolumn="MODEL_DATA",
+    )
+    add_model(
+        add_model_options=add_model_options,
+        container=calibrate_container,
+        remove_datacolumn="MODEL_DATA",
+    )
+    return wsclean_command
+
+
+task_add_model_source_list_to_ms = task(add_model_source_list_to_ms)

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -497,7 +497,7 @@ def process_science_fields(
 
     # zip up the final measurement set, which is not included in the above loop
     if field_options.zip_ms:
-        task_zip_ms.map(in_item=wsclean_cmds)
+        task_zip_ms.map(in_item=wsclean_cmds, wait_for=archive_wait_for)
 
     if field_options.sbid_archive_path or field_options.sbid_copy_path and run_aegean:
         update_archive_options = get_options_from_strategy(

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -301,6 +301,7 @@ def process_science_fields(
         strategy=unmapped(strategy),
         mode="wsclean",
         round_info="initial",
+        calibrate_container=field_options.calibrate_container,
     )  # type: ignore
 
     # TODO: This should be waited!
@@ -419,6 +420,7 @@ def process_science_fields(
                 strategy=unmapped(strategy),
                 mode="wsclean",
                 round_info=current_round,
+                calibrate_container=field_options.calibrate_container,
             )  # type: ignore
             archive_wait_for.extend(wsclean_cmds)
 

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -307,7 +307,7 @@ def process_science_fields(
     beam_summaries = task_create_beam_summary.map(
         ms=preprocess_science_mss, imageset=wsclean_cmds
     )
-
+    archive_wait_for.extend(beam_summaries)
     archive_wait_for.extend(wsclean_cmds)
 
     beam_aegean_outputs = None

--- a/tests/test_aocalibrate.py
+++ b/tests/test_aocalibrate.py
@@ -13,15 +13,35 @@ from flint.bptools.smoother import (
     smooth_data,
 )
 from flint.calibrate.aocalibrate import (
+    AddModelOptions,
     AOSolutions,
     CalibrateOptions,
     FlaggedAOSolution,
     calibrate_options_to_command,
     flag_aosolutions,
+    add_model_options_to_command,
     plot_solutions,
     select_refant,
 )
 from flint.utils import get_packaged_resource_path
+
+
+def test_generate_add_model_command():
+    """Ensure we can actually generate the expected addmodel cli command"""
+
+    add_model_options = AddModelOptions(
+        model_path=Path("/jack/sparrow/be/here/SB-sources.txt"),
+        ms_path=Path("/jack/sparrow/be/here/SB.ms"),
+        mode="c",
+        datacolumn="MODEL_DATA",
+    )
+
+    add_model_command = add_model_options_to_command(
+        add_model_options=add_model_options
+    )
+
+    expected_command = "addmodel -datacolumn MODEL_DATA -m c /jack/sparrow/be/here/SB-sources.txt /jack/sparrow/be/here/SB.ms"
+    assert add_model_command == expected_command
 
 
 def test_calibrate_options_to_command():
@@ -83,7 +103,7 @@ def test_calibrate_options_to_command3():
 
     assert (
         cmd
-        == "calibrate -datacolumn DATA -m /example/1934.model -minuv 300 -maxuv 5000 -i 40 -p amps.plot phase.plot /example/data.ms /example/sols.calibrate"
+        == "calibrate -datacolumn DATA -m /example/1934.model -minuv 300.0 -maxuv 5000.0 -i 40 -p amps.plot phase.plot /example/data.ms /example/sols.calibrate"
     )
 
 

--- a/tests/test_wsclean.py
+++ b/tests/test_wsclean.py
@@ -37,19 +37,25 @@ def test_get_wsclean_output_source_list_path():
     example = Path("/flint/pirates/SB58992.RACS_1726-73.beam22.ms")
     source_path = Path("/flint/pirates/SB58992.RACS_1726-73.beam22.i-sources.txt")
 
-    test_source_path = get_wsclean_output_source_list_path(name_path=example)
+    test_source_path = get_wsclean_output_source_list_path(name_path=example, pol="i")
     assert source_path == test_source_path
 
     example = Path("/flint/pirates/SB58992.RACS_1726-73.beam22")
     source_path = Path("/flint/pirates/SB58992.RACS_1726-73.beam22.i-sources.txt")
 
-    test_source_path = get_wsclean_output_source_list_path(name_path=example)
+    test_source_path = get_wsclean_output_source_list_path(name_path=example, pol="i")
     assert source_path == test_source_path
 
     example = "SB58992.RACS_1726-73.beam22"
     source_path = Path("SB58992.RACS_1726-73.beam22.i-sources.txt")
 
-    test_source_path = get_wsclean_output_source_list_path(name_path=example)
+    test_source_path = get_wsclean_output_source_list_path(name_path=example, pol="i")
+    assert source_path == test_source_path
+
+    example = "SB58992.RACS_1726-73.beam22"
+    source_path = Path("SB58992.RACS_1726-73.beam22-sources.txt")
+
+    test_source_path = get_wsclean_output_source_list_path(name_path=example, pol=None)
     assert source_path == test_source_path
 
 

--- a/tests/test_wsclean.py
+++ b/tests/test_wsclean.py
@@ -20,11 +20,37 @@ from flint.imager.wsclean import (
     create_wsclean_cmd,
     create_wsclean_name_argument,
     get_wsclean_output_names,
+    get_wsclean_output_source_list_path,
     rename_wsclean_prefix_in_imageset,
 )
 from flint.ms import MS
 from flint.naming import create_imaging_name_prefix
 from flint.utils import get_packaged_resource_path
+
+
+def test_get_wsclean_output_source_list_path():
+    """Wsclean can be configured out output a source list of the
+    components, their brightness and relative size that were placed
+    throughout cleaning. Here we be testing whether we can
+    generate the expected name"""
+
+    example = Path("/flint/pirates/SB58992.RACS_1726-73.beam22.ms")
+    source_path = Path("/flint/pirates/SB58992.RACS_1726-73.beam22.i-sources.txt")
+
+    test_source_path = get_wsclean_output_source_list_path(name_path=example)
+    assert source_path == test_source_path
+
+    example = Path("/flint/pirates/SB58992.RACS_1726-73.beam22")
+    source_path = Path("/flint/pirates/SB58992.RACS_1726-73.beam22.i-sources.txt")
+
+    test_source_path = get_wsclean_output_source_list_path(name_path=example)
+    assert source_path == test_source_path
+
+    example = "SB58992.RACS_1726-73.beam22"
+    source_path = Path("SB58992.RACS_1726-73.beam22.i-sources.txt")
+
+    test_source_path = get_wsclean_output_source_list_path(name_path=example)
+    assert source_path == test_source_path
 
 
 @pytest.fixture


### PR DESCRIPTION
This pull request arose after discussions around predicting a source model at full spectral resolution of a measurement set. 

To-date, the model that has been added to a MS has been at the spectral resolution set by the sub-band interval controlled via the `-channels-out` option of `wsclean`. In this sense the model that has been added to the MS is constant over each sub-band interval, which limits the usability of the model for things like continuum subtraction. 

Here an attempt is made to predict the model at full resolution by taking the component list produced by `-save-source-list`, which details all components, their scales, location and constrained SED, and which is then used by `addmodel` to predict. `addmodel` is part of the `calibrate` suite produced by Andre Offringa. 

In terms of functionality this PR adds:
- tracking of the source list file
- optionally use `addmodel` to create the MODEL_DATA between imaging rounds
- building blocks to perform continuum subtraction