### PR TITLE
Initial continuum-subtraction and spectral line prefect flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   - predicting model produced by `wsclean -save-source-list` into measurement
     set
   - using `taql` to subtract model from nominated data column
+  - added a 'flow_addmodel_to_mss` to allow different task runner to be
+    specified
 
 # 0.2.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+# dev
+
+- Created `subtract_cube_pipeline.py`
+
 # 0.2.8
 
 - added `wrapper_options_from_strategy` decorator helper function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 # dev
 
-- Created `subtract_cube_pipeline.py`
+- Created `subtract_cube_pipeline.py`. Associated changes include:
+  - wsclean imaging will delete files while still in temporary storage (for
+    instance is a ramdisk is used)
+  - added option to prefect convol task to delete files once they have be
+    convoled
 
 # 0.2.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
     instance is a ramdisk is used)
   - added option to prefect convol task to delete files once they have be
     convoled
+  - predicting model produced by `wsclean -save-source-list` into measurement
+    set
+  - using `taql` to subtract model from nominated data column
 
 # 0.2.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
   - using `taql` to subtract model from nominated data column
   - added a 'flow_addmodel_to_mss` to allow different task runner to be
     specified
+  - added `flint_no_log_wsclean_output` to `WSCleanOptions` to disable wsclean
+    logging
+  - added flag to disable logging singularity command output to the
+    `flint.logging.logger`
 
 # 0.2.8
 

--- a/README.md
+++ b/README.md
@@ -112,12 +112,8 @@ tasks together (outlined above) into a single data-processing pipeline.
   observation sequence.
 - `flint_flow_continuum_pipeline`: Performs bandpass calibration, solution
   copying, imaging, self-calibration and mosaicing.
-- `flint_flow_cointinuum_mask_pipeline`: Performs bandpass calibration, solution
-  copying, imaging, self-calibration and mosaicing. In this flow a process to
-  construct a robust clean mask is performed by exploiting an initial imaging
-  round. The field image is constructed across all beams, S/N clipping is
-  performed, then guard masks on a per-beam basis are extracted. This pipeline
-  has fallen out of use and could be removed.
+- `flint_flow_subtract_cube_pipeline`: Subtract a continuum model and image the
+  residual data.
 
 ## Sky-model catalogues
 

--- a/flint/coadd/linmos.py
+++ b/flint/coadd/linmos.py
@@ -526,6 +526,7 @@ def linmos_images(
     container: Path = Path("yandasoft.sif"),
     cutoff: float = 0.001,
     pol_axis: Optional[float] = None,
+    trim_linmos_fits: bool = True,
 ) -> LinmosCommand:
     """Create a linmos parset file and execute it.
 
@@ -538,6 +539,7 @@ def linmos_images(
         container (Path, optional): Path to the singularity container that has the yandasoft tools. Defaults to Path('yandasoft.sif').
         cutoff (float, optional): Pixels whose primary beam attenuation is below this cutoff value are blanked. Defaults to 0.001.
         pol_axis (Optional[float], optional): The physical oritentation of the ASKAP third-axis in radians. Defaults to None.
+        trim_linmos_fits (bool, optional): Attempt to trim the output linmos files of as much empty space as possible. Defaults to True.
 
     Returns:
         LinmosCommand: The linmos command executed and the associated parset file
@@ -577,11 +579,12 @@ def linmos_images(
     )
 
     # Trim the fits image to remove empty pixels
-    image_trim_results = trim_fits_image(image_path=linmos_names.image_fits)
-    trim_fits_image(
-        image_path=linmos_names.weight_fits,
-        bounding_box=image_trim_results.bounding_box,
-    )
+    if trim_linmos_fits:
+        image_trim_results = trim_fits_image(image_path=linmos_names.image_fits)
+        trim_fits_image(
+            image_path=linmos_names.weight_fits,
+            bounding_box=image_trim_results.bounding_box,
+        )
 
     return linmos_cmd
 

--- a/flint/configuration.py
+++ b/flint/configuration.py
@@ -30,7 +30,7 @@ from flint.source_finding.aegean import AegeanOptions, BANEOptions
 # into there
 
 KNOWN_HEADERS = ("defaults", "initial", "selfcal", "version")
-KNOWN_OPERATIONS = ("stokesv",)
+KNOWN_OPERATIONS = ("stokesv", "subtractcube")
 FORMAT_VERSION = 0.1
 MODE_OPTIONS_MAPPING = {
     "wsclean": WSCleanOptions,

--- a/flint/configuration.py
+++ b/flint/configuration.py
@@ -81,6 +81,32 @@ def copy_and_timestamp_strategy_file(output_dir: Path, input_yaml: Path) -> Path
     return Path(stamped_imaging_strategy)
 
 
+def _load_and_copy_strategy(
+    output_split_science_path: Path, imaging_strategy: Optional[Path] = None
+) -> Union[Strategy, None]:
+    """Load a strategy file and copy a timestamped version into the output directory
+    that would contain the science processing.
+
+    Args:
+        output_split_science_path (Path): Where the strategy file should be copied to (where the data would be processed)
+        imaging_strategy (Optional[Path], optional): Location of the strategy file. Defaults to None.
+
+    Returns:
+        Union[Strategy, None]: The loadded strategy file if provided, `None` otherwise
+    """
+    return (
+        load_strategy_yaml(
+            input_yaml=copy_and_timestamp_strategy_file(
+                output_dir=output_split_science_path,
+                input_yaml=imaging_strategy,
+            ),
+            verify=True,
+        )
+        if imaging_strategy
+        else None
+    )
+
+
 def get_selfcal_options_from_yaml(input_yaml: Optional[Path] = None) -> Dict:
     """Stub to represent interaction with a configurationf ile
 

--- a/flint/convol.py
+++ b/flint/convol.py
@@ -235,18 +235,26 @@ def convolve_images(
     if cutoff:
         logger.info(f"Supplied cutoff of {cutoff} arcsecond")
 
-    radio_beam = (
-        Beam(
-            major=beam_shape.bmaj_arcsec * u.arcsecond,
-            minor=beam_shape.bmin_arcsec * u.arcsecond,
-            pa=beam_shape.bpa_deg * u.deg,
-        )
-        if np.isfinite(beam_shape.bmaj_arcsec)
-        else Beam(
-            major=1 * u.arcsecond,
-            minor=1 * u.arcsecond,
-            pa=1 * u.deg,
-        )
+    if not np.isfinite(beam_shape.bmaj_arcsec):
+        logger.info("Beam shape is not defined. Copying files into place. ")
+        from shutil import copyfile
+
+        conv_image_paths = [
+            Path(str(image_path).replace(".fits", f".{convol_suffix}.fits"))
+            for image_path in image_paths
+        ]
+        # If the beam is not defined, simply copy the file into place. Although
+        # this takes up more space, it is not more than otherwise
+        for original_path, copy_path in zip(image_paths, conv_image_paths):
+            logger.info(f"Copying {original_path=} {copy_path=}")
+            copyfile(original_path, copy_path)
+
+        return conv_image_paths
+
+    radio_beam = Beam(
+        major=beam_shape.bmaj_arcsec * u.arcsecond,
+        minor=beam_shape.bmin_arcsec * u.arcsecond,
+        pa=beam_shape.bpa_deg * u.deg,
     )
 
     conv_image_paths: List[Path] = []

--- a/flint/convol.py
+++ b/flint/convol.py
@@ -198,10 +198,14 @@ def get_common_beam(
     if cutoff:
         logger.info(f"Setting beam cutoff to {cutoff} arcseconds. ")
 
-    beam, beams = beamcon_2D.get_common_beam(files=list(image_paths), cutoff=cutoff)
+    try:
+        beam, beams = beamcon_2D.get_common_beam(files=list(image_paths), cutoff=cutoff)
 
-    beam_shape = BeamShape.from_radio_beam(beam)
-    logger.info(f"Constructed {beam_shape=}")
+        beam_shape = BeamShape.from_radio_beam(beam)
+        logger.info(f"Constructed {beam_shape=}")
+    except ValueError:
+        logger.info("The beam was not constrained. Setting to NaNs")
+        beam_shape = BeamShape(bmaj_arcsec=np.nan, bmin_arcsec=np.nan, bpa_deg=np.nan)
 
     return beam_shape
 

--- a/flint/convol.py
+++ b/flint/convol.py
@@ -243,9 +243,9 @@ def convolve_images(
         )
         if np.isfinite(beam_shape.bmaj_arcsec)
         else Beam(
-            major=0 * u.arcsecond,
-            minor=0 * u.arcsecond,
-            pa=0 * u.deg,
+            major=1 * u.arcsecond,
+            minor=1 * u.arcsecond,
+            pa=1 * u.deg,
         )
     )
 

--- a/flint/convol.py
+++ b/flint/convol.py
@@ -235,10 +235,18 @@ def convolve_images(
     if cutoff:
         logger.info(f"Supplied cutoff of {cutoff} arcsecond")
 
-    radio_beam = Beam(
-        major=beam_shape.bmaj_arcsec * u.arcsecond,
-        minor=beam_shape.bmin_arcsec * u.arcsecond,
-        pa=beam_shape.bpa_deg * u.deg,
+    radio_beam = (
+        Beam(
+            major=beam_shape.bmaj_arcsec * u.arcsecond,
+            minor=beam_shape.bmin_arcsec * u.arcsecond,
+            pa=beam_shape.bpa_deg * u.deg,
+        )
+        if np.isfinite(beam_shape.bmaj_arcsec)
+        else Beam(
+            major=0 * u.arcsecond,
+            minor=0 * u.arcsecond,
+            pa=0 * u.deg,
+        )
     )
 
     conv_image_paths: List[Path] = []

--- a/flint/convol.py
+++ b/flint/convol.py
@@ -266,7 +266,7 @@ def convolve_images(
         header = fits.getheader(image_path)
         if header["BMAJ"] == 0.0:
             logger.info(f"Copying {image_path} to {convol_output_path=} for empty beam")
-            copyfile(original_path, copy_path)
+            copyfile(image_path, convol_output_path)
         else:
             logger.info(f"Convolving {str(image_path.name)}")
             beamcon_2D.beamcon_2d_on_fits(

--- a/flint/convol.py
+++ b/flint/convol.py
@@ -257,7 +257,7 @@ def convolve_images(
         pa=beam_shape.bpa_deg * u.deg,
     )
 
-    conv_image_paths: List[Path] = []
+    return_conv_image_paths: List[Path] = []
 
     for image_path in image_paths:
         convol_output_path = Path(
@@ -277,9 +277,9 @@ def convolve_images(
                 suffix=convol_suffix,
                 cutoff=cutoff,
             )
-        conv_image_paths.append(convol_output_path)
+        return_conv_image_paths.append(convol_output_path)
 
-    return conv_image_paths
+    return return_conv_image_paths
 
 
 def get_parser() -> ArgumentParser:

--- a/flint/exceptions.py
+++ b/flint/exceptions.py
@@ -4,6 +4,10 @@ class MSError(Exception):
     pass
 
 
+class FrequencyMismatchError(Exception):
+    """Raised when there are differences in frequencies"""
+
+
 class PhaseOutlierFitError(Exception):
     """Raised when the phase outlier fit routine fails."""
 

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -162,6 +162,8 @@ class WSCleanOptions(BaseOptions):
     """Saves the found clean components as a BBS/DP3 text sky model"""
     channel_range: Optional[Tuple[int, int]] = None
     """Image a channel range between a lower (inclusive) and upper (exclusive) bound"""
+    no_reorder: bool = False
+    """If True turn off the reordering of the MS at the beginning of wsclean"""
 
 
 class WSCleanCommand(BaseOptions):

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -325,6 +325,7 @@ def get_wsclean_output_names(
     Returns:
         ImageSet: The file paths that wsclean should create/has created.
     """
+    logger.info(f"Finding wsclean outputs, {prefix=}")
     # TODO: Use a regular expression for this
     subband_strs: List[Optional[str]] = [
         None,

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -160,6 +160,8 @@ class WSCleanOptions(BaseOptions):
     """The polarisation to be imaged"""
     save_source_list: bool = False
     """Saves the found clean components as a BBS/DP3 text sky model"""
+    channel_range: Optional[Tuple[int, int]] = None
+    """Image a channel range between a lower (inclusive) and upper (exclusive) bound"""
 
 
 class WSCleanCommand(BaseOptions):
@@ -219,6 +221,9 @@ def _rename_wsclean_title(name_str: str) -> str:
     """Construct an apply a regular expression that aims to identify
     the wsclean appended properties string within a file and replace
     the `-` separator with a `.`.
+
+    A simple replace of all `-` with `.` may not be ideal if the
+    character has been used on purpose.
 
     Args:
         name_str (str): The name that will be extracted and modified

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -848,7 +848,7 @@ def run_wsclean_imager(
 
                 wsclean_cleanup = False
             # Update the prefix based on where the files will be moved to
-            image_prefix_str = (
+            prefix = (
                 f"{str(move_hold_directories[0] / Path(prefix).name)}"
                 if image_prefix_str
                 else None

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -433,8 +433,11 @@ def create_wsclean_name_argument(wsclean_options: WSCleanOptions, ms: MS) -> Pat
 
     # Prepare the name for the output wsclean command
     # Construct the name property of the string
-    pol = wsclean_options_dict["pol"]
-    name_prefix_str = create_imaging_name_prefix(ms=ms, pol=pol)
+    pol = wsclean_options.pol
+    channel_range = wsclean_options.channel_range
+    name_prefix_str = create_imaging_name_prefix(
+        ms=ms, pol=pol, channel_range=channel_range
+    )
 
     # Now resolve the directory part
     name_dir: Union[Path, str, None] = ms.path.parent

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -220,7 +220,7 @@ def get_wsclean_output_source_list_path(
 
 
 def _rename_wsclean_title(name_str: str) -> str:
-    """Construct an apply a regular expression that aims to identify
+    """Construct and apply a regular expression that aims to identify
     the wsclean appended properties string within a file and replace
     the `-` separator with a `.`.
 
@@ -236,7 +236,7 @@ def _rename_wsclean_title(name_str: str) -> str:
     search_re = r"(-(i|q|u|v|xx|xy|yx|yy))?-((MFS|[0-9]{4}))(-t[0-9]{5})?-(image|dirty|model|residual|psf)"
     match_re = re.compile(search_re)
 
-    logger.info(f"{name_str=} {type(name_str)=}")
+    logger.info(f"Searching {name_str=} for wsclean added components")
     result = match_re.search(str(name_str))
 
     if result is None:
@@ -458,7 +458,7 @@ def wsclean_cleanup_files(
         Tuple[Path]: Set of files that were deleted
     """
     rm_files = []
-    logger.info(f"Removing wsclean files with {prefix=} {output_types}")
+    logger.info(f"Removing wsclean files with {prefix=} {output_types=}")
 
     for output_type in output_types:
         rm_files += delete_wsclean_outputs(

--- a/flint/ms.py
+++ b/flint/ms.py
@@ -656,6 +656,15 @@ def subtract_model_from_data_column(
                 [d in colnames for d in (model_column, data_column)]
             ), f"{model_column=} or {data_column=} missing from {colnames=}"
 
+            if output_column not in colnames:
+                from casacore.tables import makecoldesc
+
+                logger.info(f"Adding {output_column=}")
+                desc = makecoldesc(data_column, tab.getcoldesc(data_column))
+                desc["name"] = output_column
+                tab.addcols(desc)
+                tab.flush()
+
             logger.info(f"Subtracting {model_column=} from {data_column=}")
             taql(f"UPDATE $tab SET {output_column}={data_column}-{model_column}")
 

--- a/flint/naming.py
+++ b/flint/naming.py
@@ -5,7 +5,7 @@ products.
 import re
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, NamedTuple, Optional, Union
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union
 
 from flint.logging import logger
 from flint.options import MS
@@ -53,13 +53,18 @@ def create_image_cube_name(
     return Path(output_cube_name)
 
 
-def create_imaging_name_prefix(ms: Union[MS, Path], pol: Optional[str] = None) -> str:
+def create_imaging_name_prefix(
+    ms: Union[MS, Path],
+    pol: Optional[str] = None,
+    channel_range: Optional[Tuple[int, int]] = None,
+) -> str:
     """Given a measurement set and a polarisation, create the naming prefix to be used
     by some imager
 
     Args:
         ms (Union[MS,Path]): The measurement set being considered
         pol (Optional[str], optional): Whether a polarsation is being considered. Defaults to None.
+        channel_range (Optional[Tuple[int,int]], optional): The channel range that is going to be imaged. Defaults to none.
 
     Returns:
         str: The constructed string name
@@ -70,6 +75,8 @@ def create_imaging_name_prefix(ms: Union[MS, Path], pol: Optional[str] = None) -
     name = ms_path.stem
     if pol:
         name = f"{name}.{pol.lower()}"
+    if channel_range:
+        name = f"{name}.ch{channel_range[0]}-{channel_range[1]}"
 
     return name
 

--- a/flint/options.py
+++ b/flint/options.py
@@ -257,6 +257,8 @@ class SubtractFieldOptions(BaseOptions):
     """Primary beam attenuation cutoff to use during linmos"""
     stagger_delay_seconds: Optional[float] = None
     """The delay, in seconds, that should be used when submitting items in batches (e.g. looping over channels)"""
+    attempt_aubract: bool = False
+    """Attempt to subtract the model column from the nominated data column"""
     subtract_data_column: str = "DATA"
     """Should the continuum model be subtracted, where to store the output"""
     predict_wsclean_model: bool = False

--- a/flint/options.py
+++ b/flint/options.py
@@ -217,6 +217,34 @@ class BandpassOptions(BaseOptions):
     """Flag Jones matrix if any amplitudes with a Jones are above this value"""
 
 
+class SubtractFieldOptions(BaseOptions):
+    """Container for options related to the
+    continuum-subtracted pipeline"""
+
+    calibrate_container: Path
+    """Path to the container with the calibrate software (including addmodel)"""
+    wsclean_container: Path
+    """Path to the container with wsclean"""
+    yandasoft_container: Path
+    """Path to the container with yandasoft"""
+    subtract_model_data: bool = False
+    """Subtract the MODEL_DATA column from the nominated data column"""
+    data_column: str = "CORRECTED_DATA"
+    """Describe the column that should be imaed and, if requested, have model subtracted from"""
+    expected_ms: int = 36
+    """The number of measurement sets that should exist"""
+    imaging_strategy: Optional[Path] = None
+    """Path to a FLINT imaging yaml file that contains settings to use throughout imaging"""
+    holofile: Optional[Path] = None
+    """Path to the holography FITS cube that will be used when co-adding beams"""
+    linmos_residuals: bool = False
+    """Linmos the cleaning residuals together into a field image"""
+    beam_cutoff: float = 150
+    """Cutoff in arcseconds to use when calculating the common beam to convol to"""
+    pb_cutoff: float = 0.1
+    """Primary beam attenuation cutoff to use during linmos"""
+
+
 class FieldOptions(BaseOptions):
     """Container that represents the flint related options that
     might be used throughout components related to the actual

--- a/flint/options.py
+++ b/flint/options.py
@@ -243,10 +243,12 @@ class SubtractFieldOptions(BaseOptions):
     """Cutoff in arcseconds to use when calculating the common beam to convol to"""
     pb_cutoff: float = 0.1
     """Primary beam attenuation cutoff to use during linmos"""
-    batch_limit: int = 100
-    """Effectively batch the number of channels that can be processed concurrently to avoid overloading the system"""
     stagger_delay_seconds: Optional[float] = None
     """The delay, in seconds, that should be used when submitting items in batches (e.g. looping over channels)"""
+    subtract_data_column: str = "DATA"
+    """Should the continuum model be subtracted, where to store the output"""
+    predict_wsclean_model: bool = False
+    """Search for the continuum model produced by wsclean and subtract"""
 
 
 class FieldOptions(BaseOptions):

--- a/flint/options.py
+++ b/flint/options.py
@@ -243,6 +243,8 @@ class SubtractFieldOptions(BaseOptions):
     """Cutoff in arcseconds to use when calculating the common beam to convol to"""
     pb_cutoff: float = 0.1
     """Primary beam attenuation cutoff to use during linmos"""
+    batch_limit: int = 100
+    """Effectively batch the number of channels that can be processed concurrently to avoid overloading the system"""
 
 
 class FieldOptions(BaseOptions):

--- a/flint/options.py
+++ b/flint/options.py
@@ -217,7 +217,7 @@ class BandpassOptions(BaseOptions):
     """Flag Jones matrix if any amplitudes with a Jones are above this value"""
 
 
-class AddModelSubtractFiealOptions(BaseOptions):
+class AddModelSubtractFieldOptions(BaseOptions):
     """Options related to predicting a continuum model during the SubtractFieldOptions workflow.
     Specifically these options deal with identifying the wsclean produced source list model, which
     may be used by ``admodel`` to predict model visibilities. See utilities aroun the ``aocalibrate``
@@ -229,6 +229,8 @@ class AddModelSubtractFiealOptions(BaseOptions):
     """The polarisation of the wsclean model that was generated"""
     calibrate_container: Optional[Path] = None
     """Path to the container with the calibrate software (including addmodel)"""
+    addmodel_cluster_config: Optional[Path] = None
+    """Specify a new cluster configuration file different to the preferred on. If None, drawn from preferred cluster config"""
 
 
 class SubtractFieldOptions(BaseOptions):

--- a/flint/options.py
+++ b/flint/options.py
@@ -217,12 +217,24 @@ class BandpassOptions(BaseOptions):
     """Flag Jones matrix if any amplitudes with a Jones are above this value"""
 
 
+class AddModelSubtractFiealOptions(BaseOptions):
+    """Options related to predicting a continuum model during the SubtractFieldOptions workflow.
+    Specifically these options deal with identifying the wsclean produced source list model, which
+    may be used by ``admodel`` to predict model visibilities. See utilities aroun the ``aocalibrate``
+    functions and routines."""
+
+    attempt_addmodel: bool = False
+    """Invoke the ``addmodel`` visibility prediction, including the search for the ``wsclean`` source list"""
+    wsclean_pol_mode: List[str] = ["i"]
+    """The polarisation of the wsclean model that was generated"""
+    calibrate_container: Optional[Path] = None
+    """Path to the container with the calibrate software (including addmodel)"""
+
+
 class SubtractFieldOptions(BaseOptions):
     """Container for options related to the
     continuum-subtracted pipeline"""
 
-    calibrate_container: Path
-    """Path to the container with the calibrate software (including addmodel)"""
     wsclean_container: Path
     """Path to the container with wsclean"""
     yandasoft_container: Path

--- a/flint/options.py
+++ b/flint/options.py
@@ -257,7 +257,7 @@ class SubtractFieldOptions(BaseOptions):
     """Primary beam attenuation cutoff to use during linmos"""
     stagger_delay_seconds: Optional[float] = None
     """The delay, in seconds, that should be used when submitting items in batches (e.g. looping over channels)"""
-    attempt_subract: bool = False
+    attempt_subtract: bool = False
     """Attempt to subtract the model column from the nominated data column"""
     subtract_data_column: str = "DATA"
     """Should the continuum model be subtracted, where to store the output"""

--- a/flint/options.py
+++ b/flint/options.py
@@ -245,6 +245,8 @@ class SubtractFieldOptions(BaseOptions):
     """Primary beam attenuation cutoff to use during linmos"""
     batch_limit: int = 100
     """Effectively batch the number of channels that can be processed concurrently to avoid overloading the system"""
+    stagger_delay_seconds: Optional[float] = None
+    """The delay, in seconds, that should be used when submitting items in batches (e.g. looping over channels)"""
 
 
 class FieldOptions(BaseOptions):

--- a/flint/options.py
+++ b/flint/options.py
@@ -257,7 +257,7 @@ class SubtractFieldOptions(BaseOptions):
     """Primary beam attenuation cutoff to use during linmos"""
     stagger_delay_seconds: Optional[float] = None
     """The delay, in seconds, that should be used when submitting items in batches (e.g. looping over channels)"""
-    attempt_aubract: bool = False
+    attempt_subract: bool = False
     """Attempt to subtract the model column from the nominated data column"""
     subtract_data_column: str = "DATA"
     """Should the continuum model be subtracted, where to store the output"""

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -398,7 +398,13 @@ def task_get_common_beam(
         f"Considering {len(images_to_consider)} images across {len(wsclean_cmds)} outputs. "
     )
 
-    beam_shape = get_common_beam(image_paths=images_to_consider, cutoff=cutoff)
+    try:
+        beam_shape = get_common_beam(image_paths=images_to_consider, cutoff=cutoff)
+    except ValueError:
+        logger.critical("Failed to get beam resolution for:")
+        logger.critical(f"{images_to_consider=}")
+        logger.critical(f"{cutoff=}")
+        logger.critical(f"{filter=}")
 
     return beam_shape
 

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Collection, Dict, List, Literal, Optional, TypeVar, Union, Tuple
 
 import pandas as pd
+import numpy as np
 from prefect import task, unmapped
 from prefect.artifacts import create_table_artifact
 
@@ -398,9 +399,8 @@ def task_get_common_beam(
         f"Considering {len(images_to_consider)} images across {len(wsclean_cmds)} outputs. "
     )
 
-    try:
-        beam_shape = get_common_beam(image_paths=images_to_consider, cutoff=cutoff)
-    except ValueError:
+    beam_shape = get_common_beam(image_paths=images_to_consider, cutoff=cutoff)
+    if np.isnan(beam_shape.bmaj_arcsec):
         logger.critical("Failed to get beam resolution for:")
         logger.critical(f"{images_to_consider=}")
         logger.critical(f"{cutoff=}")

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -686,7 +686,7 @@ def _convolve_linmos(
     convol_filter: str = ".MFS.",
     convol_suffix_str: str = "conv",
     trim_linmos_fits: bool = True,
-    remove_original_image: bool = False,
+    remove_original_images: bool = False,
 ) -> LinmosCommand:
     """An internal function that launches the convolution to a common resolution
     and subsequent linmos of the wsclean residual images.
@@ -714,7 +714,7 @@ def _convolve_linmos(
         mode=convol_mode,
         filter=convol_filter,
         convol_suffix_str=convol_suffix_str,
-        remove_original_image=remove_original_image,
+        remove_original_images=remove_original_images,
     )
     assert field_options.yandasoft_container is not None
     parset = task_linmos_images.submit(

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -283,6 +283,7 @@ def task_wsclean_imager(
     wsclean_container: Path,
     update_wsclean_options: Optional[Dict[str, Any]] = None,
     fits_mask: Optional[FITSMaskNames] = None,
+    channel_range: Optional[Tuple[int, int]] = None,
 ) -> WSCleanCommand:
     """Run the wsclean imager against an input measurement set
 
@@ -291,6 +292,7 @@ def task_wsclean_imager(
         wsclean_container (Path): Path to a singularity container with wsclean packages
         update_wsclean_options (Optional[Dict[str, Any]], optional): Options to update from the default wsclean options. Defaults to None.
         fits_mask (Optional[FITSMaskNames], optional): A path to a clean guard mask. Defaults to None.
+        channel_range (Optional[Tuple[int,int]], optional): Add to the wsclean options the specific channel range to be imaged. Defaults to None.
 
     Returns:
         WSCleanCommand: A resulting wsclean command and resulting meta-data
@@ -305,6 +307,9 @@ def task_wsclean_imager(
 
     if fits_mask:
         update_wsclean_options["fits_mask"] = fits_mask.mask_fits
+
+    if channel_range:
+        update_wsclean_options["channel_range"] = channel_range
 
     logger.info(f"wsclean inager {ms=}")
     try:
@@ -577,6 +582,7 @@ def task_linmos_images(
     parset_output_path: Optional[str] = None,
     cutoff: float = 0.05,
     field_summary: Optional[FieldSummary] = None,
+    trim_linmos_fits: bool = True,
 ) -> LinmosCommand:
     """Run the yandasoft linmos task against a set of input images
 
@@ -591,6 +597,7 @@ def task_linmos_images(
         parset_output_path (Optional[str], optional): Location to write the linmos parset file to. Defaults to None.
         cutoff (float, optional): The primary beam attenuation cutoff supplied to linmos when coadding. Defaults to 0.05.
         field_summary (Optional[FieldSummary], optional): The summary of the field, including (importantly) to orientation of the third-axis. Defaults to None.
+        trim_linmos_fits (bool, optional): Attempt to trim the output linmos files of as much empty space as possible. Defaults to True.
 
     Returns:
         LinmosCommand: The linmos command and associated meta-data
@@ -649,6 +656,7 @@ def task_linmos_images(
         holofile=holofile,
         cutoff=cutoff,
         pol_axis=pol_axis,
+        trim_linmos_fits=trim_linmos_fits,
     )
 
     return linmos_cmd
@@ -663,6 +671,7 @@ def _convolve_linmos(
     convol_mode: str = "image",
     convol_filter: str = ".MFS.",
     convol_suffix_str: str = "conv",
+    trim_linmos_fits: bool = True,
 ) -> LinmosCommand:
     """An internal function that launches the convolution to a common resolution
     and subsequent linmos of the wsclean residual images.
@@ -676,6 +685,7 @@ def _convolve_linmos(
         convol_mode (str, optional): The mode passed to the convol task to describe the images to extract. Support image or residual.  Defaults to image.
         convol_filter (str, optional): A text file applied when assessing images to co-add. Defaults to '.MFS.'.
         convol_suffix_str (str, optional): The suffix added to the convolved images. Defaults to 'conv'.
+        trim_linmos_fits (bool, optional): Attempt to trim the output linmos files of as much empty space as possible. Defaults to True.
 
     Returns:
         LinmosCommand: Resulting linmos command parset
@@ -697,6 +707,7 @@ def _convolve_linmos(
         holofile=field_options.holofile,
         cutoff=field_options.pb_cutoff,
         field_summary=field_summary,
+        trim_linmos_fits=trim_linmos_fits,
     )  # type: ignore
 
     return parset

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -708,6 +708,7 @@ def _convolve_linmos(
         cutoff=field_options.pb_cutoff,
         field_summary=field_summary,
         trim_linmos_fits=trim_linmos_fits,
+        filter=convol_filter,
     )  # type: ignore
 
     return parset

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -52,7 +52,7 @@ from flint.naming import (
     get_fits_cube_from_paths,
     processed_ms_format,
 )
-from flint.options import FieldOptions
+from flint.options import FieldOptions, SubtractFieldOptions
 from flint.peel.potato import potato_peel
 from flint.prefect.common.utils import upload_image_as_artifact
 from flint.selfcal.casa import gaincal_applycal_ms
@@ -665,7 +665,7 @@ def task_linmos_images(
 def _convolve_linmos(
     wsclean_cmds: Collection[WSCleanCommand],
     beam_shape: BeamShape,
-    field_options: FieldOptions,
+    field_options: Union[FieldOptions, SubtractFieldOptions],
     linmos_suffix_str: str,
     field_summary: Optional[FieldSummary] = None,
     convol_mode: str = "image",

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -15,10 +15,9 @@ from flint.calibrate.aocalibrate import find_existing_solutions
 from flint.catalogue import verify_reference_catalogues
 from flint.coadd.linmos import LinmosCommand
 from flint.configuration import (
+    _load_and_copy_strategy,
     Strategy,
-    copy_and_timestamp_strategy_file,
     get_options_from_strategy,
-    load_strategy_yaml,
 )
 from flint.logging import logger
 from flint.masking import consider_beam_mask_round
@@ -140,32 +139,6 @@ def _check_create_output_split_science_path(
     return output_split_science_path
 
 
-def _load_and_copy_strategy(
-    output_split_science_path: Path, imaging_strategy: Optional[Path] = None
-) -> Union[Strategy, None]:
-    """Load a strategy file and copy a timestamped version into the output directory
-    that would contain the science processing.
-
-    Args:
-        output_split_science_path (Path): Where the strategy file should be copied to (where the data would be processed)
-        imaging_strategy (Optional[Path], optional): Location of the strategy file. Defaults to None.
-
-    Returns:
-        Union[Strategy, None]: The loadded strategy file if provided, `None` otherwise
-    """
-    return (
-        load_strategy_yaml(
-            input_yaml=copy_and_timestamp_strategy_file(
-                output_dir=output_split_science_path,
-                input_yaml=imaging_strategy,
-            ),
-            verify=True,
-        )
-        if imaging_strategy
-        else None
-    )
-
-
 @flow(name="Flint Continuum Pipeline")
 def process_science_fields(
     science_path: Path,
@@ -199,7 +172,7 @@ def process_science_fields(
 
     archive_wait_for: List[Any] = []
 
-    strategy = _load_and_copy_strategy(
+    strategy: Strategy = _load_and_copy_strategy(
         output_split_science_path=output_split_science_path,
         imaging_strategy=field_options.imaging_strategy,
     )

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -12,7 +12,7 @@ from typing import Tuple, Optional
 
 import numpy as np
 from configargparse import ArgumentParser
-from prefect import flow
+from prefect import flow, unmapped
 
 from flint.configuration import _load_and_copy_strategy
 from flint.exceptions import FrequencyMismatchError
@@ -105,8 +105,8 @@ def flow_subtract_cube(
         channel_wsclean_cmds = task_wsclean_imager.map(
             in_ms=science_mss,
             wsclean_container=subtract_field_options.wsclean_container,
-            channel_range=channel_range,
-            strategy=strategy,
+            channel_range=unmapped(channel_range),
+            strategy=unmapped(strategy),
             mode="wsclean",
             operation="subtractcube",
         )

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -91,7 +91,7 @@ def find_mss_to_image(
 
 
 def find_and_setup_mss(
-    science_path_or_mss: Union[Path, Tuple[MS]],
+    science_path_or_mss: Union[Path, Tuple[MS, ...]],
     expected_ms_count: int,
     data_column: str,
 ) -> Tuple[MS]:
@@ -100,7 +100,7 @@ def find_and_setup_mss(
     assume they have already been set and checked for consistency.
 
     Args:
-        science_path_or_mss (Union[Path, List[MS]]): Path to search or existing MSs
+        science_path_or_mss (Union[Path, List[MS, ...]]): Path to search or existing MSs
         expected_ms_count (int): Expected number of MSs to find
         data_column (str): The data column to nominate if creating MSs after searching
 
@@ -170,7 +170,7 @@ def task_addmodel_to_ms(
 
 @flow
 def flow_addmodel_to_mss(
-    science_path_or_mss: Union[Path, Tuple[MS]],
+    science_path_or_mss: Union[Path, Tuple[MS, ...]],
     addmodel_subtract_field_options: AddModelSubtractFieldOptions,
     expected_ms: int,
     data_column: str,

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -134,20 +134,22 @@ def flow_subtract_cube(
         )
         channel_parset_list.append(channel_parset)
         batched_channel_parset_list.append(channel_parset)
-        from prefect import states
+        from time import sleep
 
-        while len(batched_channel_parset_list) >= subtract_field_options.batch_limit:
-            future_states = [
-                future.get_state() for future in batched_channel_parset_list
-            ]
-            if any([f in (states.Failed,) for f in future_states]):
-                raise ValueError("Something failed")
+        sleep(10)
 
-            batched_channel_parset_list = [
-                b
-                for b, s in zip(batched_channel_parset_list, future_states)
-                if s != states.Completed
-            ]
+        # while len(batched_channel_parset_list) >= subtract_field_options.batch_limit:
+        #     future_states = [
+        #         future.get_state() for future in batched_channel_parset_list
+        #     ]
+        #     if any([f in (states.Failed,) for f in future_states]):
+        #         raise ValueError("Something failed")
+
+        #     batched_channel_parset_list = [
+        #         b
+        #         for b, s in zip(batched_channel_parset_list, future_states)
+        #         if s != states.Completed
+        #     ]
 
     # 4 - cube concatenated each linmos field together to single file
 

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -134,7 +134,7 @@ def flow_subtract_cube(
             channel_range=channel_range,
             strategy=strategy,
             mode="wsclean",
-            operation="subtract",
+            operation="subtractcube",
         )
         channel_beam_shape = task_get_common_beam.submit(
             wsclean_cmds=channel_wsclean_cmds,

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -147,7 +147,7 @@ def flow_subtract_cube(
             batched_channel_parset_list = [
                 b
                 for b, s in zip(batched_channel_parset_list, future_states)
-                if s == states.Completed
+                if s != states.Completed
             ]
             sleep(5)
 

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -99,6 +99,7 @@ def flow_subtract_cube(
     #   c - linmos the smoothed images together
 
     channel_parset_list = []
+    total_channel_parset_list = []
     for channel, freq_mhz in enumerate(freqs_mhz):
         logger.info(f"Imaging {channel=} {freq_mhz=}")
         channel_range = (channel, channel + 1)
@@ -127,6 +128,12 @@ def flow_subtract_cube(
             remove_original_images=True,
         )
         channel_parset_list.append(channel_parset)
+        if len(channel_parset_list) >= 50:
+            logger.info("Resolving results...")
+            total_channel_parset_list.extend(
+                [parset.result() for parset in channel_parset_list]
+            )
+            channel_parset_list = []
 
     # 4 - cube concatenated each linmos field together to single file
 

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -145,17 +145,8 @@ def flow_subtract_cube(
                     break
             else:
                 # Otherwise we will wait for the first to be
-                _ = batched_channel_parset_list.result()
+                _ = batched_channel_parset_list[0].result()
                 channel_parset_list.append(batched_channel_parset_list.pop(0))
-
-        # if len(batched_channel_parset_list) >= subtract_field_options.batch_limit:
-        #     logger.info(
-        #         f"Resolving result for batch {subtract_field_options.batch_limit}..."
-        #     )
-        #     channel_parset_list.extend(
-        #         [parset.result() for parset in batched_channel_parset_list]
-        #     )
-        #     batched_channel_parset_list = []
     else:
         channel_parset_list.extend(
             [parset.result() for parset in batched_channel_parset_list]

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -8,6 +8,7 @@ already been preprocessed and fixed.
 """
 
 from pathlib import Path
+from time import sleep
 from typing import Tuple, Optional, Any
 
 import numpy as np
@@ -97,6 +98,10 @@ def flow_subtract_cube(
     logger.info(
         f"Considering {len(freqs_mhz)} from {len(science_mss)}, minimum {np.min(freqs_mhz)}-{np.max(freqs_mhz)}"
     )
+    if len(freqs_mhz) > 20 and subtract_field_options.stagger_delay_seconds is None:
+        logger.critical(
+            f"{len(freqs_mhz)} channels and no stagger delay set! Consider setting a stagger delay"
+        )
 
     # 3 - out loop over channels to image
     #   a - wsclean map over the ms and channels
@@ -104,7 +109,6 @@ def flow_subtract_cube(
     #   c - linmos the smoothed images together
 
     channel_parset_list = []
-    batched_channel_parset_list = []
     for channel, freq_mhz in enumerate(freqs_mhz):
         logger.info(f"Imaging {channel=} {freq_mhz=}")
         channel_range = (channel, channel + 1)
@@ -133,10 +137,9 @@ def flow_subtract_cube(
             remove_original_images=True,
         )
         channel_parset_list.append(channel_parset)
-        batched_channel_parset_list.append(channel_parset)
-        from time import sleep
 
-        sleep(5)
+        if subtract_field_options.stagger_delay_seconds:
+            sleep(subtract_field_options.stagger_delay_seconds)
 
         # while len(batched_channel_parset_list) >= subtract_field_options.batch_limit:
         #     future_states = [

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -175,11 +175,12 @@ def flow_subtract_cube(
             addmodel_subtract_options=unmapped(addmodel_subtract_field_options),
         )
 
-    science_mss = task_subtract_model_from_ms.map(
-        ms=science_mss,
-        subtract_data_column=subtract_field_options.subtract_data_column,
-        update_tracked_column=True,
-    )
+    if subtract_field_options.attempt_aubract:
+        science_mss = task_subtract_model_from_ms.map(
+            ms=science_mss,
+            subtract_data_column=subtract_field_options.subtract_data_column,
+            update_tracked_column=True,
+        )
 
     channel_parset_list = []
     for channel, freq_mhz in enumerate(freqs_mhz):

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -126,7 +126,10 @@ def flow_subtract_cube(
     #   c - linmos the smoothed images together
 
     science_mss = task_subtract_model_from_ms.map(
-        ms=science_mss, model_column=unmapped("MODEL_DATA"), update_tracked_column=True
+        ms=science_mss,
+        subtract_data_column=subtract_field_options.subtract_data_column,
+        model_column=unmapped("MODEL_DATA"),
+        update_tracked_column=True,
     )
 
     channel_parset_list = []

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -175,7 +175,7 @@ def flow_subtract_cube(
             addmodel_subtract_options=unmapped(addmodel_subtract_field_options),
         )
 
-    if subtract_field_options.attempt_aubract:
+    if subtract_field_options.attempt_subract:
         science_mss = task_subtract_model_from_ms.map(
             ms=science_mss,
             subtract_data_column=subtract_field_options.subtract_data_column,

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -136,7 +136,8 @@ def flow_subtract_cube(
         output_split_science_path=science_path,
         imaging_strategy=subtract_field_options.imaging_strategy,
     )
-    _check_and_verify_options(subtract_field_options=subtract_field_options)
+    _check_and_verify_options(options=subtract_field_options)
+    _check_and_verify_options(options=addmodel_subtract_field_options)
 
     # Find the MSs
     # - optionally untar?

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -138,15 +138,14 @@ def flow_subtract_cube(
             logger.info("Popping a result")
             from prefect.states import Completed
 
-            # Attempt to find a result already completed
-            for idx, future in enumerate(batched_channel_parset_list):
-                if future.get_state() == Completed:
-                    channel_parset_list.append(batched_channel_parset_list.pop(idx))
-                    break
-            else:
-                # Otherwise we will wait for the first to be
-                _ = batched_channel_parset_list[0].result()
-                channel_parset_list.append(batched_channel_parset_list.pop(0))
+            found_a_result = False
+            while not found_a_result:
+                # Attempt to find a result already completed
+                for idx, future in enumerate(batched_channel_parset_list):
+                    if future.get_state() == Completed:
+                        channel_parset_list.append(batched_channel_parset_list.pop(idx))
+                        found_a_result = True
+                        break
     else:
         channel_parset_list.extend(
             [parset.result() for parset in batched_channel_parset_list]

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -238,7 +238,7 @@ def flow_subtract_cube(
         )(
             science_path_or_mss=science_mss,
             addmodel_subtract_field_options=addmodel_subtract_field_options,
-            expected_ms_count=subtract_field_options.expected_ms,
+            expected_ms=subtract_field_options.expected_ms,
             data_column=subtract_field_options.data_column,
         )
 

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -99,7 +99,7 @@ def flow_subtract_cube(
     #   c - linmos the smoothed images together
 
     channel_parset_list = []
-    total_channel_parset_list = []
+    batched_channel_parset_list = []
     for channel, freq_mhz in enumerate(freqs_mhz):
         logger.info(f"Imaging {channel=} {freq_mhz=}")
         channel_range = (channel, channel + 1)
@@ -127,13 +127,16 @@ def flow_subtract_cube(
             trim_linmos_fits=False,
             remove_original_images=True,
         )
-        channel_parset_list.append(channel_parset)
-        if len(channel_parset_list) >= 50:
-            logger.info("Resolving results...")
-            total_channel_parset_list.extend(
-                [parset.result() for parset in channel_parset_list]
+        batched_channel_parset_list.append(channel_parset)
+
+        if len(channel_parset_list) >= subtract_field_options.batch_limit:
+            logger.info(
+                f"Resolving result for batch {subtract_field_options.batch_limit}..."
             )
-            channel_parset_list = []
+            channel_parset_list.extend(
+                [parset.result() for parset in batched_channel_parset_list]
+            )
+            batched_channel_parset_list = []
 
     # 4 - cube concatenated each linmos field together to single file
 

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -136,7 +136,7 @@ def flow_subtract_cube(
         batched_channel_parset_list.append(channel_parset)
         from time import sleep
 
-        sleep(10)
+        sleep(5)
 
         # while len(batched_channel_parset_list) >= subtract_field_options.batch_limit:
         #     future_states = [

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -182,7 +182,7 @@ def flow_addmodel_to_mss(
     # Get the MSs that will have their model added to
     science_mss = find_and_setup_mss(
         science_path_or_mss=science_path_or_mss,
-        expected_ms=expected_ms,
+        expected_ms_count=expected_ms,
         data_column=data_column,
     )
     science_mss = task_addmodel_to_ms.map(
@@ -210,7 +210,7 @@ def flow_subtract_cube(
     # - optionally untar?
     science_mss = find_and_setup_mss(
         science_path_or_mss=science_path,
-        expected_ms=subtract_field_options.expected_ms,
+        expected_ms_count=subtract_field_options.expected_ms,
         data_column=subtract_field_options.data_column,
     )
 

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -1,0 +1,212 @@
+"""This is a workflow to subtract a continuum model and image the channel-wise data
+
+Unlike the continuum imaging and self-calibnration pipeline this flow currently
+expects that all measurement sets are in the flint format, which means other than
+the naming scheme that they have been been preprocessed to place them in the IAU
+frame and have had their fields table updated. That is to say that they have
+already been preprocessed and fixed.
+"""
+
+from pathlib import Path
+from typing import Tuple, Optional
+
+import numpy as np
+from configargparse import ArgumentParser
+from prefect import flow
+
+from flint.configuration import _load_and_copy_strategy, Strategy
+from flint.exceptions import FrequencyMismatchError
+from flint.prefect.clusters import get_dask_runner
+from flint.logging import logger
+from flint.ms import MS, find_mss, consistent_ms_frequencies, get_freqs_from_ms
+from flint.options import (
+    BaseOptions,
+    add_options_to_parser,
+    create_options_from_parser,
+)
+from flint.prefect.common.imaging import (
+    task_wsclean_imager,
+    task_get_common_beam,
+    _convolve_linmos,
+)
+from flint.naming import get_sbid_from_path
+
+
+class SubtractFieldOptions(BaseOptions):
+    """Container for options related to the
+    continuum-subtracted pipeline"""
+
+    calibrate_container: Path
+    """Path to the container with the calibrate software (including addmodel)"""
+    wsclean_container: Path
+    """Path to the container with wsclean"""
+    yandasoft_container: Path
+    """Path to the container with yandasoft"""
+    subtract_model_data: bool = False
+    """Subtract the MODEL_DATA column from the nominated data column"""
+    data_column: str = "CORRECTED_DATA"
+    """Describe the column that should be imaed and, if requested, have model subtracted from"""
+    expected_ms: int = 36
+    """The number of measurement sets that should exist"""
+    imaging_strategy: Optional[Path] = None
+    """Path to a FLINT imaging yaml file that contains settings to use throughout imaging"""
+    holofile: Optional[Path] = None
+    """Path to the holography FITS cube that will be used when co-adding beams"""
+    linmos_residuals: bool = False
+    """Linmos the cleaning residuals together into a field image"""
+    beam_cutoff: float = 150
+    """Cutoff in arcseconds to use when calculating the common beam to convol to"""
+
+
+def _check_and_verify_options(subtract_field_options: SubtractFieldOptions) -> None:
+    """Verrify that the options supplied to run the subtract field options make sense"""
+    assert (
+        subtract_field_options.calibrate_container.exists()
+        and subtract_field_options.calibrate_container.is_file()
+    ), f"{subtract_field_options.calibrate_container=} does not exist or is not a file"
+    assert (
+        subtract_field_options.wsclean_container.exists()
+        and subtract_field_options.wsclean_container.is_file()
+    ), f"{subtract_field_options.wsclean_container=} does not exist or is not a file"
+    assert (
+        subtract_field_options.yandasoft_container.exists()
+        and subtract_field_options.yandasoft_container.is_file()
+    ), f"{subtract_field_options.yandasoft_container=} does not exist or is not a file"
+
+
+def find_mss_to_image(
+    mss_parent_path: Path,
+    expected_ms_count: Optional[int] = None,
+    data_column: str = "CORRECTED_DATA",
+) -> Tuple[MS, ...]:
+    science_mss = find_mss(
+        mss_parent_path=mss_parent_path,
+        expected_ms_count=expected_ms_count,
+        data_column=data_column,
+    )
+    logger.info(f"Found {science_mss=}")
+    return science_mss
+
+
+@flow
+def flow_subtract_cube(
+    science_path: Path, subtract_field_options: SubtractFieldOptions
+) -> None:
+    strategy: Strategy = _load_and_copy_strategy(
+        output_split_science_path=science_path,
+        imaging_strategy=subtract_field_options.imaging_strategy,
+    )
+    _check_and_verify_options(subtract_field_options=subtract_field_options)
+
+    # Find the MSs
+    # - optionally untar?
+    science_mss = find_mss_to_image(
+        mss_parent_path=science_path,
+        expected_ms_count=subtract_field_options.expected_ms,
+        data_column=subtract_field_options.data_column,
+    )
+
+    # 2 - ensure matchfing frequencies over channels
+    consistent_frequencies_across_mss = consistent_ms_frequencies(mss=science_mss)
+    if not consistent_frequencies_across_mss:
+        logger.critical("Mismatch in frequencies among provided MSs")
+        raise FrequencyMismatchError("There is a mismatch in frequencies")
+
+    # 2.5 - Continuum subtract if requested
+
+    freqs_mhz = get_freqs_from_ms(ms=science_mss[0]) / 1e6
+    logger.info(
+        f"Considering {len(freqs_mhz)} from {len(science_mss)}, minimum {np.min(freqs_mhz)}-{np.max(freqs_mhz)}"
+    )
+
+    # 3 - out loop over channels to image
+    #   a - wsclean map over the ms and channels
+    #   b - convol to a common resolution for channels
+    #   c - linmos the smoothed images together
+
+    channel_parset_list = []
+    for channel, freq_mhz in enumerate(freqs_mhz):
+        logger.info(f"Imaging {channel=} {freq_mhz=}")
+        channel_range = (channel, channel + 1)
+        channel_wsclean_cmds = task_wsclean_imager.map(
+            in_ms=science_mss,
+            wsclean_container=subtract_field_options.wsclean_container,
+            channel_range=channel_range,
+            strategy=strategy,
+            mode="wsclean",
+            operation="subtract",
+        )
+        channel_beam_shape = task_get_common_beam.submit(
+            wsclean_cmds=channel_wsclean_cmds,
+            cutoff=subtract_field_options.beam_cutoff,
+            filter=".image.",
+        )
+        channel_parset = _convolve_linmos(
+            wsclean_cmds=channel_wsclean_cmds,
+            beam_shape=channel_beam_shape,
+            linmos_suffix_str=f"ch{channel_range[0]}-{channel_range[1]}",
+            convol_mode="image",
+            convol_filter=".image.",
+            convol_suffix_str="optimal.image",
+            trim_linmos_fits=False,
+        )
+        channel_parset_list.append(channel_parset)
+
+    # 4 - cube concatenated each linmos field together to single file
+
+    return
+
+
+def setup_run_subtract_flow(
+    science_path: Path,
+    subtract_field_options: SubtractFieldOptions,
+    cluster_config: Path,
+) -> None:
+    logger.info(f"Processing {science_path=}")
+    science_sbid = get_sbid_from_path(path=science_path)
+
+    dask_runner = get_dask_runner(cluster=cluster_config)
+
+    flow_subtract_cube.with_options(
+        task_runner=dask_runner, name=f"Subtract Cube Pipeline -- {science_sbid}"
+    )
+
+
+def get_parser() -> ArgumentParser:
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--cli-config", is_config_file=True, help="Path to configuration file"
+    )
+    parser.add_argument_group(
+        "science_path",
+        type=Path,
+        help="Path to the directory containing the beam-wise measurement sets",
+    )
+    parser.add_argument(
+        "--cluster-config",
+        type=str,
+        default="petrichor",
+        help="Path to a cluster configuration file, or a known cluster name. ",
+    )
+
+    parser = add_options_to_parser(parser=parser, options_class=SubtractFieldOptions)
+
+    return parser
+
+
+def cli() -> None:
+    parser = get_parser()
+
+    args = parser.parse_args()
+
+    subtract_field_options = create_options_from_parser(
+        parser_namespace=args, options_class=SubtractFieldOptions
+    )
+
+    setup_run_subtract_flow(
+        science_path=args.science_path, subtract_field_options=subtract_field_options
+    )
+
+
+if __name__ == "__main__":
+    cli()

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -124,6 +124,7 @@ def flow_subtract_cube(
             convol_filter="image.",
             convol_suffix_str="optimal.image",
             trim_linmos_fits=False,
+            remove_original_image=True,
         )
         channel_parset_list.append(channel_parset)
 

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -141,19 +141,6 @@ def flow_subtract_cube(
         if subtract_field_options.stagger_delay_seconds:
             sleep(subtract_field_options.stagger_delay_seconds)
 
-        # while len(batched_channel_parset_list) >= subtract_field_options.batch_limit:
-        #     future_states = [
-        #         future.get_state() for future in batched_channel_parset_list
-        #     ]
-        #     if any([f in (states.Failed,) for f in future_states]):
-        #         raise ValueError("Something failed")
-
-        #     batched_channel_parset_list = [
-        #         b
-        #         for b, s in zip(batched_channel_parset_list, future_states)
-        #         if s != states.Completed
-        #     ]
-
     # 4 - cube concatenated each linmos field together to single file
 
     return

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -137,6 +137,10 @@ def flow_subtract_cube(
                 [parset.result() for parset in batched_channel_parset_list]
             )
             batched_channel_parset_list = []
+    else:
+        channel_parset_list.extend(
+            [parset.result() for parset in batched_channel_parset_list]
+        )
 
     # 4 - cube concatenated each linmos field together to single file
 

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -175,7 +175,7 @@ def flow_subtract_cube(
             addmodel_subtract_options=unmapped(addmodel_subtract_field_options),
         )
 
-    if subtract_field_options.attempt_subract:
+    if subtract_field_options.attempt_subtract:
         science_mss = task_subtract_model_from_ms.map(
             ms=science_mss,
             subtract_data_column=subtract_field_options.subtract_data_column,

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -245,7 +245,7 @@ def flow_subtract_cube(
     if subtract_field_options.attempt_subtract:
         science_mss = task_subtract_model_from_ms.map(
             ms=science_mss,
-            subtract_data_column=subtract_field_options.subtract_data_column,
+            data_column=subtract_field_options.subtract_data_column,
             update_tracked_column=True,
         )
 

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -78,7 +78,7 @@ def task_subtract_model_from_ms(
 
     ms = subtract_model_from_data_column(
         ms=ms,
-        model_column="MODEL_COLUMN",
+        model_column="MODEL_DATA",
         output_column=subtract_data_column,
         update_tracked_column=update_tracked_column,
     )
@@ -128,7 +128,6 @@ def flow_subtract_cube(
     science_mss = task_subtract_model_from_ms.map(
         ms=science_mss,
         subtract_data_column=subtract_field_options.subtract_data_column,
-        model_column=unmapped("MODEL_DATA"),
         update_tracked_column=True,
     )
 

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -171,7 +171,8 @@ def flow_subtract_cube(
 
     if addmodel_subtract_field_options.attempt_addmodel:
         science_mss = task_addmodel_to_ms.map(
-            ms=science_mss, addmodel_subtract_options=addmodel_subtract_field_options
+            ms=science_mss,
+            addmodel_subtract_options=unmapped(addmodel_subtract_field_options),
         )
 
     science_mss = task_subtract_model_from_ms.map(

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -129,7 +129,7 @@ def flow_subtract_cube(
         )
         batched_channel_parset_list.append(channel_parset)
 
-        if len(channel_parset_list) >= subtract_field_options.batch_limit:
+        if len(batched_channel_parset_list) >= subtract_field_options.batch_limit:
             logger.info(
                 f"Resolving result for batch {subtract_field_options.batch_limit}..."
             )

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -114,7 +114,7 @@ def task_addmodel_to_ms(
         addmodel_options = AddModelOptions(
             model_path=wsclean_source_list_path,
             ms_path=ms.path,
-            modde="c" if idx == 0 else "a",
+            mode="c" if idx == 0 else "a",
             datacolumn="MODEL_DATA",
         )
         add_model(

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -135,7 +135,6 @@ def flow_subtract_cube(
         channel_parset_list.append(channel_parset)
         batched_channel_parset_list.append(channel_parset)
         from prefect import states
-        from time import sleep
 
         while len(batched_channel_parset_list) >= subtract_field_options.batch_limit:
             future_states = [
@@ -149,7 +148,6 @@ def flow_subtract_cube(
                 for b, s in zip(batched_channel_parset_list, future_states)
                 if s != states.Completed
             ]
-            sleep(5)
 
     # 4 - cube concatenated each linmos field together to single file
 

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -218,7 +218,7 @@ def flow_subtract_cube(
 
     freqs_mhz = get_freqs_from_ms(ms=science_mss[0]) / 1e6
     logger.info(
-        f"Considering {len(freqs_mhz)} from {len(science_mss)}, minimum {np.min(freqs_mhz)}-{np.max(freqs_mhz)}"
+        f"Considering {len(freqs_mhz)} frequencies from {len(science_mss)} channels, minimum {np.min(freqs_mhz)}-{np.max(freqs_mhz)}"
     )
     if len(freqs_mhz) > 20 and subtract_field_options.stagger_delay_seconds is None:
         logger.critical(

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -124,7 +124,7 @@ def flow_subtract_cube(
             convol_filter="image.",
             convol_suffix_str="optimal.image",
             trim_linmos_fits=False,
-            remove_original_image=True,
+            remove_original_images=True,
         )
         channel_parset_list.append(channel_parset)
 

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -182,7 +182,7 @@ def flow_addmodel_to_mss(
     # Get the MSs that will have their model added to
     science_mss = find_and_setup_mss(
         science_path_or_mss=science_path_or_mss,
-        expected_ms_count=expected_ms,
+        expected_ms=expected_ms,
         data_column=data_column,
     )
     science_mss = task_addmodel_to_ms.map(

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -144,7 +144,7 @@ def setup_run_subtract_flow(
 
     flow_subtract_cube.with_options(
         task_runner=dask_runner, name=f"Subtract Cube Pipeline -- {science_sbid}"
-    )
+    )(science_path=science_path, subtract_field_options=subtract_field_options)
 
 
 def get_parser() -> ArgumentParser:

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -113,7 +113,7 @@ def flow_subtract_cube(
         channel_beam_shape = task_get_common_beam.submit(
             wsclean_cmds=channel_wsclean_cmds,
             cutoff=subtract_field_options.beam_cutoff,
-            filter=".image.",
+            filter="image.",
         )
         channel_parset = _convolve_linmos(
             wsclean_cmds=channel_wsclean_cmds,
@@ -121,7 +121,7 @@ def flow_subtract_cube(
             linmos_suffix_str=f"ch{channel_range[0]}-{channel_range[1]}",
             field_options=subtract_field_options,
             convol_mode="image",
-            convol_filter=".image.",
+            convol_filter="image.",
             convol_suffix_str="optimal.image",
             trim_linmos_fits=False,
         )

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -210,7 +210,7 @@ def flow_subtract_cube(
     # - optionally untar?
     science_mss = find_and_setup_mss(
         science_path_or_mss=science_path,
-        expected_ms_count=subtract_field_options.expected_ms,
+        expected_ms=subtract_field_options.expected_ms,
         data_column=subtract_field_options.data_column,
     )
 

--- a/flint/sclient.py
+++ b/flint/sclient.py
@@ -16,6 +16,7 @@ def run_singularity_command(
     command: str,
     bind_dirs: Optional[Union[Path, Collection[Path]]] = None,
     stream_callback_func: Optional[Callable] = None,
+    ignore_logging_output: bool = False,
 ) -> None:
     """Executes a command within the context of a nominated singularity
     container
@@ -25,6 +26,7 @@ def run_singularity_command(
         command (str): The command to execute
         bind_dirs (Optional[Union[Path,Collection[Path]]], optional): Specifies a Path, or list of Paths, to bind to in the container. Defaults to None.
         stream_callback_func (Optional[Callable], optional): Provide a function that is applied to each line of output text when singularity is running and `stream=True`. IF provide it should accept a single (string) parameter. If None, nothing happens. Defaultds to None.
+        ignore_logging_output (bool, optional): If `True` output from the executed singularity command is not logged. Defaults to False.
 
     Raises:
         FileNotFoundError: Thrown when container image not found
@@ -65,7 +67,8 @@ def run_singularity_command(
         )
 
         for line in output:
-            logger.info(line.rstrip())
+            if not ignore_logging_output:
+                logger.info(line.rstrip())
             if stream_callback_func:
                 stream_callback_func(line)
 
@@ -103,6 +106,7 @@ def singularity_wrapper(
         container: Path,
         bind_dirs: Optional[Union[Path, Collection[Path]]] = None,
         stream_callback_func: Optional[Callable] = None,
+        ignore_logging_output: bool = False,
         **kwargs,
     ) -> str:
         """Function that can be used as a decorator on an input function. This function
@@ -113,6 +117,7 @@ def singularity_wrapper(
             container (Path): Path to the container that will be usede to execute the generated command
             bind_dirs (Optional[Union[Path,Collection[Path]]], optional): Specifies a Path, or list of Paths, to bind to in the container. Defaults to None.
             stream_callback_func (Optional[Callable], optional): Provide a function that is applied to each line of output text when singularity is running and `stream=True`. IF provide it should accept a single (string) parameter. If None, nothing happens. Defaultds to None.
+            ignore_logging_output (bool, optional): If `True` output from the executed singularity command is not logged. Defaults to False.
 
         Returns:
             str: The command that was executed
@@ -129,6 +134,7 @@ def singularity_wrapper(
             image=container,
             command=f"{task_str}",
             bind_dirs=bind_dirs,
+            ignore_logging_output=ignore_logging_output,
             stream_callback_func=stream_callback_func,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ flint_potato = "flint.peel.potato:cli"
 flint_leakage = "flint.leakage:cli"
 flint_flow_bandpass_calibrate = "flint.prefect.flows.bandpass_pipeline:cli"
 flint_flow_continuum_pipeline = "flint.prefect.flows.continuum_pipeline:cli"
-flint_flow_continuum_mask_pipeline = "flint.prefect.flows.continuum_mask_pipeline:cli"
+flint_flow_subtract_cube_pipeline = "fline.prefect.flows.subtract_cube_pipeline:cli"
 
 [[tool.mypy.overrides]]
 module = "astropy.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ flint_potato = "flint.peel.potato:cli"
 flint_leakage = "flint.leakage:cli"
 flint_flow_bandpass_calibrate = "flint.prefect.flows.bandpass_pipeline:cli"
 flint_flow_continuum_pipeline = "flint.prefect.flows.continuum_pipeline:cli"
-flint_flow_subtract_cube_pipeline = "fline.prefect.flows.subtract_cube_pipeline:cli"
+flint_flow_subtract_cube_pipeline = "flint.prefect.flows.subtract_cube_pipeline:cli"
 
 [[tool.mypy.overrides]]
 module = "astropy.*"

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from flint.ms import MS
 from flint.naming import (
     CASDANameComponents,
     FITSMaskNames,
@@ -14,6 +15,7 @@ from flint.naming import (
     casda_ms_format,
     create_fits_mask_names,
     create_image_cube_name,
+    create_imaging_name_prefix,
     create_ms_name,
     extract_beam_from_name,
     extract_components_from_name,
@@ -26,6 +28,25 @@ from flint.naming import (
     processed_ms_format,
     raw_ms_format,
 )
+
+
+def test_create_imaging_name_prefix():
+    """Creates the name that will be used for output image
+    products"""
+    ms = MS.cast(ms=Path("/Jack/Sparrow/SB63789.EMU_1743-51.beam03.round4.ms"))
+
+    name = create_imaging_name_prefix(ms=ms)
+    assert name == "SB63789.EMU_1743-51.beam03.round4"
+
+    for pol in ("I", "i"):
+        name = create_imaging_name_prefix(ms=ms, pol=pol)
+        assert name == "SB63789.EMU_1743-51.beam03.round4.i"
+
+        name = create_imaging_name_prefix(ms=ms, pol=pol, channel_range=(100, 108))
+        assert name == "SB63789.EMU_1743-51.beam03.round4.i.ch100-108"
+
+    name = create_imaging_name_prefix(ms=ms, channel_range=(100, 108))
+    assert name == "SB63789.EMU_1743-51.beam03.round4.ch100-108"
 
 
 def test_get_cube_fits_from_paths():

--- a/tests/test_prefect_subtractcube_flow.py
+++ b/tests/test_prefect_subtractcube_flow.py
@@ -1,0 +1,9 @@
+"""Tests around the subtract cube imaging flow"""
+
+from flint.prefect.flows.subtract_cube_pipeline import get_parser
+
+
+def test_get_parser():
+    """Make sure the parser can actually be builts"""
+    # This is a silly one but I was bitten by it not working, arrrrhh matey
+    _ = get_parser()

--- a/tests/test_wsclean.py
+++ b/tests/test_wsclean.py
@@ -473,3 +473,22 @@ def test_wsclean_output_named_nomfs():
     assert image_set.psf is not None
     assert len(image_set.psf) == 4
     assert isinstance(image_set.psf[0], Path)
+
+
+def test_wsclean_names_no_subbands():
+    """The spectral line modes image per channel, so there is therefore no subband type
+    in the wsclean named output"""
+    image_set = get_wsclean_output_names(
+        prefix="JackSparrow", subbands=1, include_mfs=False
+    )
+
+    assert isinstance(image_set, ImageSet)
+    assert image_set.prefix == "JackSparrow"
+
+    assert image_set.image
+    assert len(image_set.image) == 1
+    assert image_set.image[0] == Path("JackSparrow-image.fits")
+
+    assert image_set.psf
+    assert len(image_set.psf) == 1
+    assert image_set.psf[0] == Path("JackSparrow-psf.fits")

--- a/tests/test_wsclean.py
+++ b/tests/test_wsclean.py
@@ -292,6 +292,13 @@ def test_resolve_key_value_to_cli():
     assert res.bindpath is None
     assert res.unknown == ("temp_dir", unknown)
 
+    ignore = WSCleanOptions
+    res = _resolve_wsclean_key_value_to_cli_str("flint_this_should_be_ignored", ignore)
+    assert res.cmd is None
+    assert res.bindpath is None
+    assert res.unknown is None
+    assert res.ignore
+
 
 def test_create_wsclean_name(ms_example):
     """Test the creation of a wsclean name argument"""

--- a/tests/test_wsclean.py
+++ b/tests/test_wsclean.py
@@ -181,6 +181,14 @@ def test_regex_rename_wsclean_title():
     out_ex = "SB39400.RACS_0635-31.beam33.poli.i.MFS.image"
     assert _rename_wsclean_title(name_str=ex) == out_ex
 
+    ex = "SB39400.RACS_0635-31.beam33.ch109-110-i-MFS-image"
+    out_ex = "SB39400.RACS_0635-31.beam33.ch109-110.i.MFS.image"
+    assert _rename_wsclean_title(name_str=ex) == out_ex
+
+    ex = "SB39400.RACS_0635-31.beam33.i.ch109-110-i-MFS-image"
+    out_ex = "SB39400.RACS_0635-31.beam33.i.ch109-110.i.MFS.image"
+    assert _rename_wsclean_title(name_str=ex) == out_ex
+
 
 def test_regex_stokes_wsclean_title():
     """Test whether all stokes values are picked up properly"""


### PR DESCRIPTION
This is an initial attempt at implementing a basic workflow to handle the processing of spectral line data. 

It is a little hefty. What is in it?
- Additional option to output a 'source component' list from `wsclean` with its `-save-source-list` option. This is a sky-model file of each clean component and the corresponding SED that was constrained. 
- An CLI call to the `addmodel` program that forms part of Andre Offringa's `calibrate` program, which can predict the model visibilities of components described by the sky-model at full channel resolution
- A helper function to subtract a model column from a data column via `taql`, which should scale to large MSs
- initial workflow to perform the continuum model prediction, subtraction, imaging, convolving and co-adding of the continuum-subtracted data

Of less importance are:
- Some initial helper logic to delay the task creation and submission loop across channels
- The `addmodel` prediction being carried out in a subflow with a different data runner. This is the first time such an approach has been used, so may change
- An optional toggle in the singularity command execution to not log container output to the flint logger. This may help lower stress on the prefect server
- The addition of a `flint_no_log_wsclean_output` attribute to `WSCleanOptions`, which is a directive for flint more than something that influences wsclean

Points to think further about:
- Whether the `flint_no_log_wsclean_output` is a usage pattern that is acceptable. Would having a separate `FlintOptions` to control these miscellaneous things be better? 
  - Did it this way as `WSCleanOptions` was already being passed all the way through. Alternatives would include passing any `FlintOptions` all the way through helper functions, or perhaps using environment variables to control points like this.  
- Are we happy with the current way the subflow is invoked? 
