### PR TITLE
Remove weight text files after linmos in spectral line flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@
   - added flag to disable logging singularity command output to the
     `flint.logging.logger`
   - subtract flow will remove files whenever possible (remove original files
-    after convolving, removing convolved files after linmos, remove linmos after
-    combining)
+    after convolving, removing convolved files after linmos, remove channel
+    linmos images after combining into a cube, removing the weight text files)
 
 # 0.2.8
 

--- a/flint/coadd/linmos.py
+++ b/flint/coadd/linmos.py
@@ -545,6 +545,7 @@ def generate_linmos_parameter_set(
     return linmos_parset_summary
 
 
+# TODO: These options are starting to get a little large. Perhaps we should use BaseOptions.
 def linmos_images(
     images: Collection[Path],
     parset_output_path: Path,

--- a/flint/coadd/linmos.py
+++ b/flint/coadd/linmos.py
@@ -545,6 +545,26 @@ def generate_linmos_parameter_set(
     return linmos_parset_summary
 
 
+def _linmos_cleanup(linmos_parset_summary: LinmosParsetSummary) -> Tuple[Path, ...]:
+    """Clean up linmos files if requested.
+
+    Args:
+        linmos_parset_summary (LinmosParsetSummary): Parset summary from which the text file weights are gathered for deletion from
+
+    Returns:
+        Tuple[Path, ...]: Set of files removed
+    """
+
+    from flint.utils import remove_files_folders
+
+    removed_files = []
+    if linmos_parset_summary.weight_text_paths is not None:
+        removed_files.extend(
+            remove_files_folders(*linmos_parset_summary.weight_text_paths)
+        )
+    return tuple(removed_files)
+
+
 # TODO: These options are starting to get a little large. Perhaps we should use BaseOptions.
 def linmos_images(
     images: Collection[Path],
@@ -619,12 +639,7 @@ def linmos_images(
         )
 
     if cleanup:
-        if linmos_parset_summary.weight_text_paths is not None:
-            logger.info(
-                f"Remoing {len(linmos_parset_summary.weight_text_paths)} weight files generated"
-            )
-            for weight_file in linmos_parset_summary.weight_text_paths:
-                Path(weight_file).unlink()
+        _linmos_cleanup(linmos_parset_summary=linmos_parset_summary)
 
     return linmos_cmd
 

--- a/flint/coadd/linmos.py
+++ b/flint/coadd/linmos.py
@@ -530,8 +530,8 @@ def generate_linmos_parameter_set(
 
     linmos_parset_summary = LinmosParsetSummary(
         parset_path=parset_output_path,
-        weight_text_paths=tuple(weight_list),
-        image_paths=tuple(img_list),
+        weight_text_paths=tuple([Path(wi) for wi in weight_list]),
+        image_paths=tuple([Path(i) for i in img_list]),
     )
 
     return linmos_parset_summary
@@ -614,7 +614,7 @@ def linmos_images(
             f"Remoing {len(linmos_parset_summary.weight_text_paths)} weight files generated"
         )
         [
-            weight_file.unlink()
+            Path(weight_file).unlink()
             for weight_file in linmos_parset_summary.weight_text_paths
         ]
 

--- a/flint/coadd/linmos.py
+++ b/flint/coadd/linmos.py
@@ -47,10 +47,10 @@ class LinmosParsetSummary(NamedTuple):
 
     parset_path: Path
     """Path to the parset text file created"""
-    weight_text_paths: Optional[Tuple[Path, ...]] = None
-    """The set of Paths to the text files with per channel weights used by linmos"""
     image_paths: Tuple[Path, ...]
     """The set of paths to the fits images that were coadded together"""
+    weight_text_paths: Optional[Tuple[Path, ...]] = None
+    """The set of Paths to the text files with per channel weights used by linmos"""
 
 
 def _create_bound_box_plane(
@@ -487,12 +487,12 @@ def generate_linmos_parameter_set(
         assert (
             weight_files is not None
         ), f"{weight_files=}, which should not happen after creating weight files"
-        weight_str = [
+        _weight_str = [
             str(weight_file)
             for weight_file in weight_files
             if Path(weight_file).exists()
         ]
-        weight_str = "[" + ",".join(weight_str) + "]"
+        weight_str = "[" + ",".join(_weight_str) + "]"
 
     beam_order_strs = [str(extract_beam_from_name(str(p.name))) for p in images]
     beam_order_list = "[" + ",".join(beam_order_strs) + "]"
@@ -622,10 +622,8 @@ def linmos_images(
             logger.info(
                 f"Remoing {len(linmos_parset_summary.weight_text_paths)} weight files generated"
             )
-            [
+            for weight_file in linmos_parset_summary.weight_text_paths:
                 Path(weight_file).unlink()
-                for weight_file in linmos_parset_summary.weight_text_paths
-            ]
 
     return linmos_cmd
 

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -651,6 +651,8 @@ def task_linmos_images(
 
     pol_axis = field_summary.pol_axis if field_summary else None
 
+    # TODO: Perhaps the 'remove_original_files' should also be dealt with
+    # internally by linmos_images
     linmos_cmd = linmos_images(
         images=filter_images,
         parset_output_path=Path(output_path),

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -597,6 +597,7 @@ def task_linmos_images(
     field_summary: Optional[FieldSummary] = None,
     trim_linmos_fits: bool = True,
     remove_original_images: bool = False,
+    cleanup: bool = False,
 ) -> LinmosCommand:
     """Run the yandasoft linmos task against a set of input images
 
@@ -611,6 +612,7 @@ def task_linmos_images(
         field_summary (Optional[FieldSummary], optional): The summary of the field, including (importantly) to orientation of the third-axis. Defaults to None.
         trim_linmos_fits (bool, optional): Attempt to trim the output linmos files of as much empty space as possible. Defaults to True.
         remove_original_images (bool, optional): If True remove the original image after they have been convolved. Defaults to False.
+        cleanup (bool, optional): Clean up items created throughout linmos, including the per-channl weight text files for each input image. Defaults to False.
 
     Returns:
         LinmosCommand: The linmos command and associated meta-data
@@ -658,6 +660,7 @@ def task_linmos_images(
         cutoff=cutoff,
         pol_axis=pol_axis,
         trim_linmos_fits=trim_linmos_fits,
+        cleanup=cleanup,
     )
     if remove_original_images:
         logger.info(f"Removing {len(filter_images)} input images")
@@ -677,6 +680,7 @@ def _convolve_linmos(
     convol_suffix_str: str = "conv",
     trim_linmos_fits: bool = True,
     remove_original_images: bool = False,
+    cleanup_linmos: bool = False,
 ) -> LinmosCommand:
     """An internal function that launches the convolution to a common resolution
     and subsequent linmos of the wsclean residual images.
@@ -692,6 +696,7 @@ def _convolve_linmos(
         convol_suffix_str (str, optional): The suffix added to the convolved images. Defaults to 'conv'.
         trim_linmos_fits (bool, optional): Attempt to trim the output linmos files of as much empty space as possible. Defaults to True.
         remove_original_images (bool, optional): If True remove the original image after they have been convolved. Defaults to False.
+        cleanup_linmos (bool, optional): Clean up items created throughout linmos, including the per-channl weight text files for each input image. Defaults to False.
 
     Returns:
         LinmosCommand: Resulting linmos command parset
@@ -717,6 +722,7 @@ def _convolve_linmos(
         trim_linmos_fits=trim_linmos_fits,
         filter=convol_filter,
         remove_original_images=remove_original_images,
+        cleanup=cleanup_linmos,
     )  # type: ignore
 
     return parset

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -334,6 +334,7 @@ def flow_subtract_cube(
             convol_suffix_str="optimal.image",
             trim_linmos_fits=False,  # This is necessary to ensure all images have same pixel-coordinates
             remove_original_images=True,
+            cleanup_linmos=True,
         )
         channel_parset_list.append(channel_parset)
 


### PR DESCRIPTION
The channel-wise linmos procedure creates many small text files when computing the channel weights. This PR introduces a new option to remove them when linmos has completed. This required some small changes to the helper function in the linmos call. 