### PR TITLE
Add a timelimit context handler, eye towards BANE deadlocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   - subtract flow will remove files whenever possible (remove original files
     after convolving, removing convolved files after linmos, remove channel
     linmos images after combining into a cube, removing the weight text files)
+- Added a `timelimit_on_context` helper to raise an error after some specified
+  length of time. Looking at you, BANE and issue #186. Arrrr.
 
 # 0.2.8
 

--- a/flint/coadd/linmos.py
+++ b/flint/coadd/linmos.py
@@ -526,7 +526,9 @@ def generate_linmos_parameter_set(
     )
     # Construct the holography section of the linmos parset
     parset += _get_holography_linmos_options(
-        holofile=holofile, pol_axis=pol_axis, remove_leakage=".i." not in str(images[0])
+        holofile=holofile,
+        pol_axis=pol_axis,
+        remove_leakage=".i." not in str(list(images)[0]),
     )
 
     # Now write the file, me hearty

--- a/flint/exceptions.py
+++ b/flint/exceptions.py
@@ -1,30 +1,42 @@
-class MSError(Exception):
+class FlintException(Exception):
+    """Base exception for Flint"""
+
+    pass
+
+
+class TimeLimitException(FlintException):
+    """A function has taken too long to execute"""
+
+    pass
+
+
+class MSError(FlintException):
     """An error for MS related things"""
 
     pass
 
 
-class FrequencyMismatchError(Exception):
+class FrequencyMismatchError(FlintException):
     """Raised when there are differences in frequencies"""
 
 
-class PhaseOutlierFitError(Exception):
+class PhaseOutlierFitError(FlintException):
     """Raised when the phase outlier fit routine fails."""
 
     pass
 
 
-class GainCalError(Exception):
+class GainCalError(FlintException):
     """Raised when it appears like the casa gaincal task fails."""
 
     pass
 
 
-class CleanDivergenceError(Exception):
+class CleanDivergenceError(FlintException):
     """Raised if it is detected that cleaning has diverged."""
 
     pass
 
 
-class TarArchiveError(Exception):
+class TarArchiveError(FlintException):
     """Raised it the flint tarball is not created successfullty"""

--- a/tests/test_linmos_coadd.py
+++ b/tests/test_linmos_coadd.py
@@ -148,11 +148,19 @@ def test_linmos_holo_options(tmpdir):
 
     parset = _get_holography_linmos_options(holofile=holofile, pol_axis=None)
     assert "linmos.primarybeam      = ASKAP_PB\n" in parset
-    assert "linmos.removeleakage    = true\n" in parset
+    assert "linmos.removeleakage    = false\n" in parset
     assert f"linmos.primarybeam.ASKAP_PB.image = {str(holofile.absolute())}\n" in parset
     assert "linmos.primarybeam.ASKAP_PB.alpha" not in parset
 
     parset = _get_holography_linmos_options(holofile=holofile, pol_axis=np.deg2rad(-45))
+    assert "linmos.primarybeam      = ASKAP_PB\n" in parset
+    assert "linmos.removeleakage    = false\n" in parset
+    assert f"linmos.primarybeam.ASKAP_PB.image = {str(holofile.absolute())}\n" in parset
+    assert "linmos.primarybeam.ASKAP_PB.alpha" in parset
+
+    parset = _get_holography_linmos_options(
+        holofile=holofile, remove_leakage=True, pol_axis=np.deg2rad(-45)
+    )
     assert "linmos.primarybeam      = ASKAP_PB\n" in parset
     assert "linmos.removeleakage    = true\n" in parset
     assert f"linmos.primarybeam.ASKAP_PB.image = {str(holofile.absolute())}\n" in parset

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,7 +39,7 @@ def some_long_function(minimum_time=5):
     t1 = time.time()
     while time.time() - t1 < minimum_time:
         sum = 0
-        for i in range(100000000):
+        for i in range(1000):
             sum = sum + 1
     print(f"Time taken: {time.time() - t1} seconds")
 
@@ -50,8 +50,11 @@ def test_timelimit_on_context():
         with timelimit_on_context(timelimit_seconds=1):
             some_long_function(minimum_time=20)
 
-    with timelimit_on_context(timelimit_seconds=2000):
+    with timelimit_on_context(timelimit_seconds=5):
         some_long_function(minimum_time=1)
+
+    # This should make sure that the signal is not raised after the context left
+    some_long_function(minimum_time=5)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@
 import math
 import os
 import shutil
+import time
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +15,7 @@ from astropy.io import fits
 from astropy.wcs import WCS
 
 from flint.convol import BeamShape
+from flint.exceptions import TimeLimitException
 from flint.logging import logger
 from flint.utils import (
     SlurmInfo,
@@ -29,7 +31,27 @@ from flint.utils import (
     hold_then_move_into,
     log_job_environment,
     temporarily_move_into,
+    timelimit_on_context,
 )
+
+
+def some_long_function(minimum_time=5):
+    t1 = time.time()
+    while time.time() - t1 < minimum_time:
+        sum = 0
+        for i in range(100000000):
+            sum = sum + 1
+    print(f"Time taken: {time.time() - t1} seconds")
+
+
+def test_timelimit_on_context():
+    """Raise an error should a function take longer than expected to run"""
+    with pytest.raises(TimeLimitException):
+        with timelimit_on_context(timelimit_seconds=1):
+            some_long_function(minimum_time=20)
+
+    with timelimit_on_context(timelimit_seconds=2000):
+        some_long_function(minimum_time=1)
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
It has been noted that under some strange set of circumstances that BANE can get into a deadlock. There has been some issue raised here for a while (#187 ). 

This is a heavy handed attempt to fix it. It establishes a timelimit on the execution of the bane and aegean tasks. Nominally this is set to 45 minutes. 

Really this should be fixed where it is an actually problem. Something in BANE, sharedmemory and heavy loads is causing something to go wrong. But for the moment this will do. 