### PR TITLE
Add callback for BANE singularity stream handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
     linmos images after combining into a cube, removing the weight text files)
 - Added a `timelimit_on_context` helper to raise an error after some specified
   length of time. Looking at you, BANE and issue #186. Arrrr.
+- Added a `BANE` callback handler to attempt to help #186. This includes a
+  `AttemptRerunException` and corresponding code in `run_singularity_comand` to
+  retry the failing command.
 
 # 0.2.8
 

--- a/flint/exceptions.py
+++ b/flint/exceptions.py
@@ -4,6 +4,12 @@ class FlintException(Exception):
     pass
 
 
+class AttemptRerunException(FlintException):
+    """Intended to be used in stream call back functions to
+    capture strange errors and signify that they should be
+    rerun. For instance, strange BANE deadlocking errors."""
+
+
 class TimeLimitException(FlintException):
     """A function has taken too long to execute"""
 

--- a/flint/source_finding/aegean.py
+++ b/flint/source_finding/aegean.py
@@ -77,6 +77,7 @@ def _bane_output_callback(line: str) -> None:
     assert isinstance(line, str)
 
     if "must be strictly ascending or descending" in line:
+        logger.info("Potential BANE deadlock detectedc. Sleeping and raising error.")
         from time import sleep
 
         sleep(2)

--- a/flint/source_finding/aegean.py
+++ b/flint/source_finding/aegean.py
@@ -77,6 +77,9 @@ def _bane_output_callback(line: str) -> None:
     assert isinstance(line, str)
 
     if "must be strictly ascending or descending" in line:
+        from time import sleep
+
+        sleep(2)
         raise AttemptRerunException("BANE deadlock detected. ")
 
 

--- a/tests/test_aegean.py
+++ b/tests/test_aegean.py
@@ -3,14 +3,34 @@ tools used in flint. BANE is also used to derive signal maps that ultimately
 feed the clean mask creation.
 """
 
+import pytest
 from pathlib import Path
 
+from flint.exceptions import AttemptRerunException
 from flint.source_finding.aegean import (
     AegeanOptions,
     BANEOptions,
+    _bane_output_callback,
     _get_aegean_command,
     _get_bane_command,
 )
+
+
+def test_bane_deadlock_callback():
+    """Noticed that BANE sometimes goes into a 'deadlock' state, and will
+    seemingly always issue an log (from scipy, presumably, arrr)
+    around interpolation not being strictly ascending"""
+
+    lines = (
+        "30146:INFO using 8 cores",
+        "30146:INFO using 7 stripes",
+        "30343:WARNING The points in dimension 0 must be strictly ascending or descending",
+    )
+    _bane_output_callback(line=lines[0])
+    _bane_output_callback(line=lines[1])
+
+    with pytest.raises(AttemptRerunException):
+        _bane_output_callback(line=lines[2])
 
 
 def test_bane_options():


### PR DESCRIPTION
Its been noted that sometimes BANE gets into a weird deadlock type error. I suspect it is some strange conspiracy that could be eliminated with changes to BANE and its uses of shared memory and load on the system. I can not reliably reproduce it. 

This pull request attempts to detect the deadlock mode, and raise an error, which is subsequently prompts flint to rerun the singularity command. 