### PR TITLE
Added type hints to prefect wrapped tasks

### DIFF
--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -7,11 +7,11 @@ imaging flows.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Collection, Literal, TypeVar
+from typing import Any, Collection, Literal, ParamSpec, TypeVar
 
 import numpy as np
 import pandas as pd
-from prefect import task, unmapped
+from prefect import Task, task, unmapped
 from prefect.artifacts import create_table_artifact
 
 from flint.calibrate.aocalibrate import (
@@ -68,13 +68,18 @@ from flint.validation import (
     create_validation_tables,
 )
 
+P = ParamSpec("P")
+R = TypeVar("R")
+
 # These are simple task wrapped functions and require no other modification
-task_copy_and_preprocess_casda_askap_ms = task(copy_and_preprocess_casda_askap_ms)
-task_preprocess_askap_ms = task(preprocess_askap_ms)
-task_split_by_field = task(split_by_field)
-task_select_solution_for_ms = task(select_aosolution_for_ms)
-task_create_apply_solutions_cmd = task(create_apply_solutions_cmd)
-task_rename_column_in_ms = task(rename_column_in_ms)
+task_copy_and_preprocess_casda_askap_ms: Task[P, R] = task(
+    copy_and_preprocess_casda_askap_ms
+)
+task_preprocess_askap_ms: Task[P, R] = task(preprocess_askap_ms)
+task_split_by_field: Task[P, R] = task(split_by_field)
+task_select_solution_for_ms: Task[P, R] = task(select_aosolution_for_ms)
+task_create_apply_solutions_cmd: Task[P, R] = task(create_apply_solutions_cmd)
+task_rename_column_in_ms: Task[P, R] = task(rename_column_in_ms)
 
 # Tasks below are extracting componented from earlier stages, or are
 # otherwise doing something important
@@ -406,7 +411,7 @@ def get_common_beam_from_images(
     return beam_shape
 
 
-task_get_common_beam_from_images = task(get_common_beam_from_images)
+task_get_common_beam_from_images: Task[P, R] = task(get_common_beam_from_images)
 
 
 def get_common_beam_from_image_set(
@@ -434,7 +439,7 @@ def get_common_beam_from_image_set(
     )
 
 
-task_get_common_beam_from_image_set = task(get_common_beam_from_image_set)
+task_get_common_beam_from_image_set: Task[P, R] = task(get_common_beam_from_image_set)
 
 
 def get_common_beam_from_image_sets(
@@ -465,7 +470,7 @@ def get_common_beam_from_image_sets(
     )
 
 
-task_get_common_beam_from_image_sets = task(get_common_beam_from_image_sets)
+task_get_common_beam_from_image_sets: Task[P, R] = task(get_common_beam_from_image_sets)
 
 
 def get_common_beam_from_results(
@@ -504,7 +509,7 @@ def get_common_beam_from_results(
     )
 
 
-task_get_common_beam_from_results = task(get_common_beam_from_results)
+task_get_common_beam_from_results: Task[P, R] = task(get_common_beam_from_results)
 
 
 @task
@@ -675,7 +680,7 @@ def convolve_image_set(
     return convolved_images
 
 
-task_convolve_image_set = task(convolve_image_set)
+task_convolve_image_set: Task[P, R] = task(convolve_image_set)
 
 
 @task

--- a/flint/prefect/common/ms.py
+++ b/flint/prefect/common/ms.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import ParamSpec, TypeVar
 
-from prefect import task
+from prefect import Task, task
 
 from flint.calibrate.aocalibrate import AddModelOptions, add_model
 from flint.imager.wsclean import WSCleanResult
 from flint.logging import logger
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 # TODO: This can be a dispatcher type function should
@@ -48,4 +52,4 @@ def add_model_source_list_to_ms(
     return wsclean_command
 
 
-task_add_model_source_list_to_ms = task(add_model_source_list_to_ms)
+task_add_model_source_list_to_ms: Task[P, R] = task(add_model_source_list_to_ms)

--- a/flint/prefect/common/utils.py
+++ b/flint/prefect/common/utils.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import base64
 from pathlib import Path
-from typing import Any, Iterable, TypeVar
+from typing import Any, Iterable, ParamSpec, TypeVar
 from uuid import UUID
 
-from prefect import task
+from prefect import Task, task
 from prefect.artifacts import create_markdown_artifact
 
 from flint.archive import copy_sbid_files_archive, create_sbid_tar_archive
@@ -26,6 +26,8 @@ from flint.summary import (
 )
 
 T = TypeVar("T")
+P = ParamSpec("P")
+R = TypeVar("R")
 
 SUPPORTED_IMAGE_TYPES = ("png",)
 
@@ -104,11 +106,11 @@ def upload_image_as_artifact(image_path: Path, description: str | None = None) -
     return image_uuid  # type: ignore
 
 
-task_update_field_summary = task(update_field_summary)
-task_create_field_summary = task(create_field_summary)
-task_create_beam_summary = task(create_beam_summary)
-task_get_fits_cube_from_paths = task(get_fits_cube_from_paths)
-task_rename_linear_to_stokes = task(rename_linear_to_stokes)
+task_update_field_summary: Task[P, R] = task(update_field_summary)
+task_create_field_summary: Task[P, R] = task(create_field_summary)
+task_create_beam_summary: Task[P, R] = task(create_beam_summary)
+task_get_fits_cube_from_paths: Task[P, R] = task(get_fits_cube_from_paths)
+task_rename_linear_to_stokes: Task[P, R] = task(rename_linear_to_stokes)
 
 
 @task


### PR DESCRIPTION
The usage of inline wrapped tasks like 

```
from prefect import task
from flint.utils import some_func

task_come_func = task(some_func)
```

meant that type information was not being passed along in the same way as

```
@task
def task_some_fun():
```

This PR is a first step to that, though still could be incomplete. 