### PR TITLE
Removed the 'get_options_from_strategy' wrapper function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   - An alternative to the `addmodel` program
   - Patches into the existing Dask client
   - Requires version bump to `numpy>=2.0` in `flint` and associated dependencies
+- Removed the `wrapper_get_options_from_strategy`
 
 # 0.2.13
 

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -21,7 +21,6 @@ from flint.calibrate.aocalibrate import (
     select_aosolution_for_ms,
 )
 from flint.coadd.linmos import LinmosOptions, LinmosResult, linmos_images
-from flint.configuration import wrapper_options_from_strategy
 from flint.convol import (
     BeamShape,
     convolve_cubes,
@@ -242,7 +241,6 @@ def task_zip_ms(in_item: WSCleanResult) -> Path:
 
 
 @task
-@wrapper_options_from_strategy(update_options_keyword="update_gain_cal_options")
 def task_gaincal_applycal_ms(
     ms: MS | WSCleanResult,
     selfcal_round: int,
@@ -293,7 +291,6 @@ def task_gaincal_applycal_ms(
 
 
 @task
-@wrapper_options_from_strategy(update_options_keyword="update_wsclean_options")
 def task_wsclean_imager(
     in_ms: ApplySolutions | MS,
     wsclean_container: Path,
@@ -990,7 +987,6 @@ def create_convolve_linmos_cubes(
 
 
 @task
-@wrapper_options_from_strategy(update_options_keyword="update_masking_options")
 def task_create_image_mask_model(
     image: LinmosResult | ImageSet | WSCleanResult,
     image_products: AegeanOutputs,

--- a/flint/prefect/common/utils.py
+++ b/flint/prefect/common/utils.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Iterable, ParamSpec, TypeVar
 from uuid import UUID
 
-from prefect import Task, task
+from prefect import task
 from prefect.artifacts import create_markdown_artifact
 
 from flint.archive import copy_sbid_files_archive, create_sbid_tar_archive
@@ -106,11 +106,11 @@ def upload_image_as_artifact(image_path: Path, description: str | None = None) -
     return image_uuid  # type: ignore
 
 
-task_update_field_summary: Task[P, R] = task(update_field_summary)
-task_create_field_summary: Task[P, R] = task(create_field_summary)
-task_create_beam_summary: Task[P, R] = task(create_beam_summary)
-task_get_fits_cube_from_paths: Task[P, R] = task(get_fits_cube_from_paths)
-task_rename_linear_to_stokes: Task[P, R] = task(rename_linear_to_stokes)
+task_update_field_summary = task(update_field_summary)
+task_create_field_summary = task(create_field_summary)
+task_create_beam_summary = task(create_beam_summary)
+task_get_fits_cube_from_paths = task(get_fits_cube_from_paths)
+task_rename_linear_to_stokes = task(rename_linear_to_stokes)
 
 
 @task

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -361,7 +361,7 @@ def process_science_fields(
                 rename_ms=field_options.rename_ms,
                 archive_cal_table=True,
                 casa_container=field_options.casa_container,
-                update_gaincal_options=unmapped(
+                update_gain_cal_options=unmapped(
                     get_options_from_strategy(
                         strategy=strategy,
                         mode="gaincal",

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -274,11 +274,13 @@ def process_science_fields(
     wsclean_results = task_wsclean_imager.map(
         in_ms=preprocess_science_mss,
         wsclean_container=field_options.wsclean_container,
-        update_wsclean_options=get_options_from_strategy(
-            strategy=strategy,
-            mode="wsclean",
-            round_info=0,
-            operation="selfcal",
+        update_wsclean_options=unmapped(
+            get_options_from_strategy(
+                strategy=strategy,
+                mode="wsclean",
+                round_info=0,
+                operation="selfcal",
+            )
         ),
     )  # type: ignore
 
@@ -359,11 +361,13 @@ def process_science_fields(
                 rename_ms=field_options.rename_ms,
                 archive_cal_table=True,
                 casa_container=field_options.casa_container,
-                update_gaincal_options=get_options_from_strategy(
-                    strategy=strategy,
-                    mode="gaincal",
-                    round_info=current_round,
-                    operation="selfcal",
+                update_gaincal_options=unmapped(
+                    get_options_from_strategy(
+                        strategy=strategy,
+                        mode="gaincal",
+                        round_info=current_round,
+                        operation="selfcal",
+                    )
                 ),
                 wait_for=[
                     field_summary
@@ -397,11 +401,13 @@ def process_science_fields(
                 fits_beam_masks = task_create_image_mask_model.map(
                     image=wsclean_results,
                     image_products=beam_aegean_outputs,
-                    update_masking_options=get_options_from_strategy(
-                        strategy=strategy,
-                        mode="masking",
-                        round_info=current_round,
-                        operation="selfcal",
+                    update_masking_options=unmapped(
+                        get_options_from_strategy(
+                            strategy=strategy,
+                            mode="masking",
+                            round_info=current_round,
+                            operation="selfcal",
+                        )
                     ),
                 )  # type: ignore
 
@@ -409,11 +415,13 @@ def process_science_fields(
                 in_ms=cal_mss,
                 wsclean_container=field_options.wsclean_container,
                 fits_mask=fits_beam_masks,
-                update_wsclean_options=get_options_from_strategy(
-                    strategy=strategy,
-                    mode="wsclean",
-                    operation="selfcal",
-                    round_info=current_round,
+                update_wsclean_options=unmapped(
+                    get_options_from_strategy(
+                        strategy=strategy,
+                        mode="wsclean",
+                        operation="selfcal",
+                        round_info=current_round,
+                    )
                 ),
             )
             wsclean_results = (

--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -274,10 +274,12 @@ def process_science_fields(
     wsclean_results = task_wsclean_imager.map(
         in_ms=preprocess_science_mss,
         wsclean_container=field_options.wsclean_container,
-        strategy=unmapped(strategy),
-        mode="wsclean",
-        round_info=0,
-        operation="selfcal",
+        update_wsclean_options=get_options_from_strategy(
+            strategy=strategy,
+            mode="wsclean",
+            round_info=0,
+            operation="selfcal",
+        ),
     )  # type: ignore
 
     wsclean_results = (
@@ -357,10 +359,12 @@ def process_science_fields(
                 rename_ms=field_options.rename_ms,
                 archive_cal_table=True,
                 casa_container=field_options.casa_container,
-                strategy=unmapped(strategy),
-                mode="gaincal",
-                round_info=current_round,
-                operation="selfcal",
+                update_gaincal_options=get_options_from_strategy(
+                    strategy=strategy,
+                    mode="gaincal",
+                    round_info=current_round,
+                    operation="selfcal",
+                ),
                 wait_for=[
                     field_summary
                 ],  # To make sure field summary is created with unzipped MSs
@@ -393,21 +397,25 @@ def process_science_fields(
                 fits_beam_masks = task_create_image_mask_model.map(
                     image=wsclean_results,
                     image_products=beam_aegean_outputs,
-                    strategy=unmapped(strategy),
-                    mode="masking",
-                    round_info=current_round,
-                    operation="selfcal",
+                    update_masking_options=get_options_from_strategy(
+                        strategy=strategy,
+                        mode="masking",
+                        round_info=current_round,
+                        operation="selfcal",
+                    ),
                 )  # type: ignore
 
             wsclean_results = task_wsclean_imager.map(
                 in_ms=cal_mss,
                 wsclean_container=field_options.wsclean_container,
                 fits_mask=fits_beam_masks,
-                strategy=unmapped(strategy),
-                mode="wsclean",
-                operation="selfcal",
-                round_info=current_round,
-            )  # type: ignore
+                update_wsclean_options=get_options_from_strategy(
+                    strategy=strategy,
+                    mode="wsclean",
+                    operation="selfcal",
+                    round_info=current_round,
+                ),
+            )
             wsclean_results = (
                 task_add_model_source_list_to_ms.map(
                     wsclean_command=wsclean_results,

--- a/flint/prefect/flows/polarisation_pipeline.py
+++ b/flint/prefect/flows/polarisation_pipeline.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from configargparse import ArgumentParser
-from prefect import flow, tags
+from prefect import flow, tags, unmapped
 from prefect.futures import PrefectFuture
 
 from flint.coadd.linmos import LinmosResult
@@ -110,11 +110,13 @@ def process_science_fields_pol(
                         in_ms=science_ms,
                         wsclean_container=pol_field_options.wsclean_container,
                         make_cube_from_subbands=False,  # We will do this later
-                        update_wsclean_options=get_options_from_strategy(
-                            strategy=strategy,
-                            operation="polarisation",
-                            mode="wsclean",
-                            polarisation=polarisation,
+                        update_wsclean_options=unmapped(
+                            get_options_from_strategy(
+                                strategy=strategy,
+                                operation="polarisation",
+                                mode="wsclean",
+                                polarisation=polarisation,
+                            )
                         ),
                     )
                 )

--- a/flint/prefect/flows/polarisation_pipeline.py
+++ b/flint/prefect/flows/polarisation_pipeline.py
@@ -9,6 +9,7 @@ from prefect.futures import PrefectFuture
 from flint.coadd.linmos import LinmosResult
 from flint.configuration import (
     POLARISATION_MAPPING,
+    get_options_from_strategy,
     load_and_copy_strategy,
 )
 from flint.convol import task_convolve_images
@@ -108,11 +109,13 @@ def process_science_fields_pol(
                     task_wsclean_imager.submit(
                         in_ms=science_ms,
                         wsclean_container=pol_field_options.wsclean_container,
-                        strategy=strategy,
-                        operation="polarisation",
-                        mode="wsclean",
-                        polarisation=polarisation,
                         make_cube_from_subbands=False,  # We will do this later
+                        update_wsclean_options=get_options_from_strategy(
+                            strategy=strategy,
+                            operation="polarisation",
+                            mode="wsclean",
+                            polarisation=polarisation,
+                        ),
                     )
                 )
                 _image_set: PrefectFuture[ImageSet] = task_getattr.submit(

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -411,10 +411,12 @@ def flow_subtract_cube(
             in_ms=science_mss,
             wsclean_container=subtract_field_options.wsclean_container,
             channel_range=unmapped(channel_range),
-            update_wsclean_options=get_options_from_strategy(
-                strategy=strategy,
-                mode="wsclean",
-                operation="subtractcube",
+            update_wsclean_options=unmapped(
+                get_options_from_strategy(
+                    strategy=strategy,
+                    mode="wsclean",
+                    operation="subtractcube",
+                )
             ),
         )
         channel_beam_shape = task_get_common_beam_from_results.submit(

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -18,7 +18,7 @@ from fitscube.combine_fits import combine_fits
 from prefect import flow, task, unmapped
 
 from flint.coadd.linmos import LinmosResult
-from flint.configuration import load_and_copy_strategy
+from flint.configuration import get_options_from_strategy, load_and_copy_strategy
 from flint.exceptions import FrequencyMismatchError
 from flint.logging import logger
 from flint.ms import (
@@ -411,9 +411,11 @@ def flow_subtract_cube(
             in_ms=science_mss,
             wsclean_container=subtract_field_options.wsclean_container,
             channel_range=unmapped(channel_range),
-            strategy=unmapped(strategy),
-            mode="wsclean",
-            operation="subtractcube",
+            update_wsclean_options=get_options_from_strategy(
+                strategy=strategy,
+                mode="wsclean",
+                operation="subtractcube",
+            ),
         )
         channel_beam_shape = task_get_common_beam_from_results.submit(
             wsclean_results=channel_wsclean_cmds,

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -4,7 +4,6 @@ import filecmp
 from pathlib import Path
 
 import pytest
-from click import MissingParameter
 
 from flint.configuration import (
     Strategy,
@@ -16,7 +15,6 @@ from flint.configuration import (
     get_selfcal_options_from_yaml,
     load_strategy_yaml,
     verify_configuration,
-    wrapper_options_from_strategy,
     write_strategy_to_yaml,
 )
 from flint.utils import get_packaged_resource_path
@@ -281,74 +279,6 @@ def test_get_mask_options_from_path(package_strategy_path):
             continue
 
         assert masking[k] == masking2[k]
-
-
-@wrapper_options_from_strategy(update_options_keyword="update_options")
-def return_values(val, update_options=None):
-    "example doc string"
-    return val, update_options
-
-
-def test_wrapper_function_val(package_strategy_path):
-    """See if the wrapper to get strategy options from a file works nicely"""
-
-    # These asserts make sure that the  properties of the wrappede function are
-    # carried forward to the returned function
-    assert return_values.__name__ == "return_values"
-    assert return_values.__doc__ == "example doc string"
-    in_val = "ThisIsJack"
-    val, update_options = return_values(val=in_val, strategy=package_strategy_path)
-    assert val == in_val
-
-    # This makes sure that we can override the lookup from the strategy file
-    # by explicitly passing through the update_options keyword
-    val, update_options = return_values(
-        val=in_val, update_options="ignoring", strategy=package_strategy_path
-    )
-    assert val == in_val
-    assert update_options == "ignoring"
-
-    val, update_options = return_values(
-        val=in_val,
-        strategy=Path(package_strategy_path),
-        mode="masking",
-        round_info=0,
-    )
-
-    assert val == in_val
-    assert isinstance(update_options, dict)
-    assert update_options["flood_fill_positive_seed_clip"] == 4.5
-
-
-@wrapper_options_from_strategy(update_options_keyword="update_options")
-def print_return_values(update_options):
-    "example doc string"
-    return "Jack", update_options
-
-
-def test_wrapper_function(package_strategy_path):
-    """See if the wrapper to get strategy options from a file works nicely"""
-
-    # These asserts make sure that the  properties of the wrappede function are
-    # carried forward to the returned function
-    assert print_return_values.__name__ == "print_return_values"
-    assert print_return_values.__doc__ == "example doc string"
-    val, update_options = print_return_values(strategy=package_strategy_path)
-    assert val == "Jack"
-
-    val, update_options = print_return_values(
-        strategy=Path(package_strategy_path), mode="masking", round_info=0
-    )
-
-    assert val == "Jack"
-    assert isinstance(update_options, dict)
-    assert update_options["flood_fill_positive_seed_clip"] == 4.5
-
-    with pytest.raises(MissingParameter):
-
-        @wrapper_options_from_strategy(update_options_keyword="JackNotHere")
-        def no_workie():
-            return 1
 
 
 def test_get_modes(package_strategy):


### PR DESCRIPTION
This pull request removed the `wrapper_get_options_from_strategy` function, and updates appropriately calls into functions that referenced it. 

There were a couple reasons for this:
- unless you were the captain it was hard to know from the code exclusively
- it seems as though that is is currently not possible to appropriately add the additional keyword only tags that `get_options_from_strategy` introduces into the signature of the returned wrapped function. See https://peps.python.org/pep-0612/#concatenating-keyword-parameters

To avoid confusion, reduce number of code and keep things explicit it seems to me the best course of action is to simply remove it. Which I have. Ye harrrr. 