### PR TITLE
Using an explicit keyword argument name during calibrate

### DIFF
--- a/flint/calibrate/aocalibrate.py
+++ b/flint/calibrate/aocalibrate.py
@@ -461,7 +461,7 @@ def find_existing_solutions(
     calibrate_cmds = [
         CalibrateCommand(
             cmd="None",
-            ms=MS(ms),
+            ms=MS(path=ms),
             solution_path=solution_path,
             model=Path("None"),
             preflagged=True,

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -185,6 +185,8 @@ class WSCleanOptions(BaseOptions):
     """If True turn off the reordering of the MS at the beginning of wsclean"""
     no_mf_weighting: bool = False
     """Opposite of -ms-weighting; can be used to turn off MF weighting in -join-channels mode"""
+    taper_gaussian: float | None = None
+    """The size of a Gaussian function applied to the weights, assuming units of arcseconds. Defaults to None. """
     # Options below here are not added to wsclean command
     flint_make_cube_inplace: bool = True
     """Rotate the cube for the linmos axis ordering in place, or do it via a temporary file that then gets deleted. Good thing to turn off when getting weird OSErrors on file writing"""


### PR DESCRIPTION
I was applying some bandpass solutions to some racs-low3 data during some re-imaging and came across a strange `KeyError` when creating an `MS` instance:

```python
calibrate_cmds = [
        CalibrateCommand(
            cmd="None",
            ms=MS(path=ms),
            solution_path=solution_path,
            model=Path("None"),
            preflagged=True,
        )
        for (ms, solution_path) in zip(bandpass_mss, solution_paths)
    ]
```

Investigating it does seem like there is some regression somewhere, but we have avoided it as we generally always use keyword=values in all of our code. 

```
In [1]: from flint.ms import MS

In [2]: from pathlib import Path

In [3]: a = Path("test.ms")

In [4]: MS(a)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[4], line 1
----> 1 MS(a)

TypeError: BaseModel.__init__() takes 1 positional argument but 2 were given

In [5]: MS(path=a)
Out[5]: MS(path=PosixPath('test.ms'), column=None, beam=None, spw=None, field=None, model_column=None)

In [6]: MS.cast(a)
Out[6]: MS(path=PosixPath('test.ms'), column=None, beam=None, spw=None, field=None, model_column=None)

```

Honestly kind of surprised we have not found this out earlier. I suppose we have been very consistent and avoided it outright. Its not clear to me why there is a difference in these. 